### PR TITLE
feat: API-023 회고 검색 API 구현

### DIFF
--- a/codes/server/src/domain/retrospect/dto.rs
+++ b/codes/server/src/domain/retrospect/dto.rs
@@ -422,6 +422,46 @@ pub struct SuccessRetrospectDetailResponse {
     pub result: RetrospectDetailResponse,
 }
 
+// ============================================
+// API-023: 회고 검색 DTO
+// ============================================
+
+/// 회고 검색 쿼리 파라미터
+#[derive(Debug, Deserialize, IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchQueryParams {
+    /// 검색 키워드 (프로젝트명/회고명 기준, 1~100자, 필수)
+    pub keyword: String,
+}
+
+/// 회고 검색 결과 아이템
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchRetrospectItem {
+    /// 회고 고유 식별자
+    pub retrospect_id: i64,
+    /// 프로젝트 이름
+    pub project_name: String,
+    /// 팀 이름
+    pub team_name: String,
+    /// 회고 방식
+    pub retrospect_method: RetrospectMethod,
+    /// 회고 날짜 (YYYY-MM-DD)
+    pub retrospect_date: String,
+    /// 회고 시간 (HH:mm)
+    pub retrospect_time: String,
+}
+
+/// Swagger용 회고 검색 성공 응답 타입
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuccessSearchResponse {
+    pub is_success: bool,
+    pub code: String,
+    pub message: String,
+    pub result: Vec<SearchRetrospectItem>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1133,5 +1173,135 @@ mod tests {
         // Assert
         assert_eq!(json["index"], 3);
         assert_eq!(json["content"], "테스트 질문입니다");
+    }
+
+    // ========================================
+    // API-023: SearchRetrospectItem 직렬화 테스트
+    // ========================================
+
+    #[test]
+    fn should_serialize_search_retrospect_item_in_camel_case() {
+        // Arrange
+        let item = SearchRetrospectItem {
+            retrospect_id: 42,
+            project_name: "스프린트 회고".to_string(),
+            team_name: "팀A".to_string(),
+            retrospect_method: RetrospectMethod::Kpt,
+            retrospect_date: "2026-01-24".to_string(),
+            retrospect_time: "14:30".to_string(),
+        };
+
+        // Act
+        let json = serde_json::to_value(&item).unwrap();
+
+        // Assert
+        assert_eq!(json["retrospectId"], 42);
+        assert_eq!(json["projectName"], "스프린트 회고");
+        assert_eq!(json["teamName"], "팀A");
+        assert_eq!(json["retrospectMethod"], "KPT");
+        assert_eq!(json["retrospectDate"], "2026-01-24");
+        assert_eq!(json["retrospectTime"], "14:30");
+        // snake_case 키가 없는지 확인
+        assert!(json.get("retrospect_id").is_none());
+        assert!(json.get("project_name").is_none());
+        assert!(json.get("team_name").is_none());
+        assert!(json.get("retrospect_method").is_none());
+        assert!(json.get("retrospect_date").is_none());
+        assert!(json.get("retrospect_time").is_none());
+    }
+
+    #[test]
+    fn should_serialize_search_response_with_all_retrospect_methods() {
+        // Arrange & Act & Assert
+        let methods = vec![
+            (RetrospectMethod::Kpt, "KPT"),
+            (RetrospectMethod::FourL, "FOUR_L"),
+            (RetrospectMethod::FiveF, "FIVE_F"),
+            (RetrospectMethod::Pmi, "PMI"),
+            (RetrospectMethod::Free, "FREE"),
+        ];
+
+        for (method, expected) in methods {
+            let item = SearchRetrospectItem {
+                retrospect_id: 1,
+                project_name: "테스트".to_string(),
+                team_name: "팀".to_string(),
+                retrospect_method: method,
+                retrospect_date: "2026-01-01".to_string(),
+                retrospect_time: "10:00".to_string(),
+            };
+
+            let json = serde_json::to_value(&item).unwrap();
+            assert_eq!(json["retrospectMethod"], expected);
+        }
+    }
+
+    #[test]
+    fn should_serialize_success_search_response_in_camel_case() {
+        // Arrange
+        let response = SuccessSearchResponse {
+            is_success: true,
+            code: "COMMON200".to_string(),
+            message: "검색을 성공했습니다.".to_string(),
+            result: vec![SearchRetrospectItem {
+                retrospect_id: 1,
+                project_name: "테스트 프로젝트".to_string(),
+                team_name: "팀A".to_string(),
+                retrospect_method: RetrospectMethod::Kpt,
+                retrospect_date: "2026-01-24".to_string(),
+                retrospect_time: "14:00".to_string(),
+            }],
+        };
+
+        // Act
+        let json = serde_json::to_value(&response).unwrap();
+
+        // Assert
+        assert_eq!(json["isSuccess"], true);
+        assert_eq!(json["code"], "COMMON200");
+        assert_eq!(json["result"].as_array().unwrap().len(), 1);
+        assert_eq!(json["result"][0]["retrospectId"], 1);
+        assert_eq!(json["result"][0]["projectName"], "테스트 프로젝트");
+    }
+
+    #[test]
+    fn should_serialize_empty_search_response() {
+        // Arrange
+        let response = SuccessSearchResponse {
+            is_success: true,
+            code: "COMMON200".to_string(),
+            message: "검색을 성공했습니다.".to_string(),
+            result: vec![],
+        };
+
+        // Act
+        let json = serde_json::to_value(&response).unwrap();
+
+        // Assert
+        assert_eq!(json["result"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn should_deserialize_search_query_params_with_keyword() {
+        // Arrange
+        let json = r#"{"keyword": "스프린트"}"#;
+
+        // Act
+        let params: SearchQueryParams = serde_json::from_str(json).unwrap();
+
+        // Assert
+        assert_eq!(params.keyword, "스프린트");
+    }
+
+    #[test]
+    fn should_fail_deserialize_search_query_params_without_keyword() {
+        // Arrange
+        let json = r#"{}"#;
+
+        // Act
+        let result: Result<SearchQueryParams, _> = serde_json::from_str(json);
+
+        // Assert
+        assert!(result.is_err());
     }
 }

--- a/codes/server/src/domain/retrospect/handler.rs
+++ b/codes/server/src/domain/retrospect/handler.rs
@@ -10,10 +10,10 @@ use crate::utils::error::AppError;
 use crate::utils::BaseResponse;
 
 use super::dto::{
-    CreateParticipantResponse, CreateRetrospectRequest, CreateRetrospectResponse,
-    DraftSaveRequest, DraftSaveResponse, ReferenceItem, RetrospectDetailResponse,
-    StorageQueryParams, StorageResponse, SubmitRetrospectRequest, SubmitRetrospectResponse,
-    TeamRetrospectListItem,
+    CreateParticipantResponse, CreateRetrospectRequest, CreateRetrospectResponse, DraftSaveRequest,
+    DraftSaveResponse, ReferenceItem, RetrospectDetailResponse, SearchQueryParams,
+    SearchRetrospectItem, StorageQueryParams, StorageResponse, SubmitRetrospectRequest,
+    SubmitRetrospectResponse, TeamRetrospectListItem,
 };
 use super::service::RetrospectService;
 
@@ -407,5 +407,45 @@ pub async fn get_storage(
     Ok(Json(BaseResponse::success_with_message(
         result,
         "보관함 조회를 성공했습니다.",
+    )))
+}
+
+/// 회고 검색 API (API-023)
+///
+/// 사용자가 참여하는 모든 팀의 회고를 프로젝트명/회고명 기준으로 검색합니다.
+/// 결과는 회고 날짜 내림차순(최신순), 동일 날짜인 경우 회고 시간 내림차순으로 정렬됩니다.
+#[utoipa::path(
+    get,
+    path = "/api/v1/retrospects/search",
+    params(SearchQueryParams),
+    security(
+        ("bearer_auth" = [])
+    ),
+    responses(
+        (status = 200, description = "검색을 성공했습니다.", body = SuccessSearchResponse),
+        (status = 400, description = "검색어 누락 또는 유효하지 않음", body = ErrorResponse),
+        (status = 401, description = "인증 실패", body = ErrorResponse),
+        (status = 500, description = "서버 내부 오류", body = ErrorResponse)
+    ),
+    tag = "Retrospect"
+)]
+pub async fn search_retrospects(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Query(params): Query<SearchQueryParams>,
+) -> Result<Json<BaseResponse<Vec<SearchRetrospectItem>>>, AppError> {
+    // 사용자 ID 추출
+    let user_id: i64 = user
+        .0
+        .sub
+        .parse()
+        .map_err(|_| AppError::Unauthorized("유효하지 않은 사용자 ID입니다.".to_string()))?;
+
+    // 서비스 호출
+    let result = RetrospectService::search_retrospects(state, user_id, params).await?;
+
+    Ok(Json(BaseResponse::success_with_message(
+        result,
+        "검색을 성공했습니다.",
     )))
 }

--- a/codes/server/src/main.rs
+++ b/codes/server/src/main.rs
@@ -20,12 +20,12 @@ use crate::domain::member::entity::member_retro::RetrospectStatus;
 use crate::domain::retrospect::dto::{
     CreateParticipantResponse, CreateRetrospectRequest, CreateRetrospectResponse, DraftItem,
     DraftSaveRequest, DraftSaveResponse, ReferenceItem, RetrospectDetailResponse,
-    RetrospectMemberItem, RetrospectQuestionItem, StorageRangeFilter, StorageResponse,
-    StorageRetrospectItem, StorageYearGroup, SubmitAnswerItem, SubmitRetrospectRequest,
-    SubmitRetrospectResponse, SuccessCreateParticipantResponse, SuccessCreateRetrospectResponse,
-    SuccessDraftSaveResponse, SuccessReferencesListResponse, SuccessRetrospectDetailResponse,
-    SuccessStorageResponse, SuccessSubmitRetrospectResponse, SuccessTeamRetrospectListResponse,
-    TeamRetrospectListItem,
+    RetrospectMemberItem, RetrospectQuestionItem, SearchRetrospectItem, StorageRangeFilter,
+    StorageResponse, StorageRetrospectItem, StorageYearGroup, SubmitAnswerItem,
+    SubmitRetrospectRequest, SubmitRetrospectResponse, SuccessCreateParticipantResponse,
+    SuccessCreateRetrospectResponse, SuccessDraftSaveResponse, SuccessReferencesListResponse,
+    SuccessRetrospectDetailResponse, SuccessSearchResponse, SuccessStorageResponse,
+    SuccessSubmitRetrospectResponse, SuccessTeamRetrospectListResponse, TeamRetrospectListItem,
 };
 use crate::domain::retrospect::entity::retrospect::RetrospectMethod;
 use crate::state::AppState;
@@ -46,7 +46,8 @@ use crate::utils::{BaseResponse, ErrorResponse};
         domain::retrospect::handler::save_draft,
         domain::retrospect::handler::get_retrospect_detail,
         domain::retrospect::handler::submit_retrospect,
-        domain::retrospect::handler::get_storage
+        domain::retrospect::handler::get_storage,
+        domain::retrospect::handler::search_retrospects
     ),
     components(
         schemas(
@@ -84,7 +85,9 @@ use crate::utils::{BaseResponse, ErrorResponse};
             RetrospectDetailResponse,
             RetrospectMemberItem,
             RetrospectQuestionItem,
-            SuccessRetrospectDetailResponse
+            SuccessRetrospectDetailResponse,
+            SearchRetrospectItem,
+            SuccessSearchResponse
         )
     ),
     tags(
@@ -177,6 +180,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route(
             "/api/v1/retrospects/:retrospect_id/references",
             axum::routing::get(domain::retrospect::handler::list_references),
+        )
+        .route(
+            "/api/v1/retrospects/search",
+            axum::routing::get(domain::retrospect::handler::search_retrospects),
         )
         .route(
             "/api/v1/retrospects/storage",

--- a/codes/server/src/utils/error.rs
+++ b/codes/server/src/utils/error.rs
@@ -67,6 +67,9 @@ pub enum AppError {
 
     /// RETRO4033: 이미 제출 완료 (403)
     RetroAlreadySubmitted(String),
+
+    /// SEARCH4001: 검색어 누락 또는 유효하지 않음 (400)
+    SearchKeywordInvalid(String),
 }
 
 impl AppError {
@@ -91,6 +94,7 @@ impl AppError {
             AppError::RetroAnswerTooLong(msg) => msg.clone(),
             AppError::RetroAnswerWhitespaceOnly(msg) => msg.clone(),
             AppError::RetroAlreadySubmitted(msg) => msg.clone(),
+            AppError::SearchKeywordInvalid(msg) => msg.clone(),
         }
     }
 
@@ -115,6 +119,7 @@ impl AppError {
             AppError::RetroAnswerTooLong(_) => "RETRO4003",
             AppError::RetroAnswerWhitespaceOnly(_) => "RETRO4007",
             AppError::RetroAlreadySubmitted(_) => "RETRO4033",
+            AppError::SearchKeywordInvalid(_) => "SEARCH4001",
         }
     }
 
@@ -139,6 +144,7 @@ impl AppError {
             AppError::RetroAnswerTooLong(_) => StatusCode::BAD_REQUEST,
             AppError::RetroAnswerWhitespaceOnly(_) => StatusCode::BAD_REQUEST,
             AppError::RetroAlreadySubmitted(_) => StatusCode::FORBIDDEN,
+            AppError::SearchKeywordInvalid(_) => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/docs/reviews/api-023-retrospect-search.md
+++ b/docs/reviews/api-023-retrospect-search.md
@@ -1,0 +1,104 @@
+# API-023: 회고 검색 API 구현 리뷰
+
+## 개요
+사용자가 참여하는 모든 팀의 회고를 프로젝트명/회고명 기준으로 검색하는 API입니다.
+
+## 엔드포인트
+- **Method**: `GET`
+- **Path**: `/api/v1/retrospects/search`
+- **인증**: Bearer Token 필수
+
+## 요청
+| 파라미터 | 타입 | 필수 | 설명 |
+|----------|------|------|------|
+| keyword | string | Y | 검색 키워드 (1~100자) |
+
+## 응답
+```json
+{
+  "isSuccess": true,
+  "code": "COMMON200",
+  "message": "검색을 성공했습니다.",
+  "result": [
+    {
+      "retrospectId": 42,
+      "projectName": "스프린트 회고",
+      "teamName": "팀A",
+      "retrospectMethod": "KPT",
+      "retrospectDate": "2026-01-24",
+      "retrospectTime": "14:30"
+    }
+  ]
+}
+```
+
+## 에러 코드
+| 코드 | HTTP | 설명 |
+|------|------|------|
+| SEARCH4001 | 400 | 검색어 누락 또는 유효하지 않음 |
+| AUTH4001 | 401 | 인증 실패 |
+| COMMON500 | 500 | 서버 내부 오류 |
+
+## 구현 세부사항
+
+### 변경 파일
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/utils/error.rs` | `SearchKeywordInvalid` 에러 변형 추가 (SEARCH4001) |
+| `src/domain/retrospect/dto.rs` | `SearchQueryParams`, `SearchRetrospectItem`, `SuccessSearchResponse` DTO 추가 |
+| `src/domain/retrospect/service.rs` | `search_retrospects` 비즈니스 로직 구현 |
+| `src/domain/retrospect/handler.rs` | `search_retrospects` 핸들러 추가 |
+| `src/main.rs` | 라우트 등록 및 Swagger 스키마 추가 |
+
+### 비즈니스 로직 흐름
+1. 키워드 검증 (`validate_search_keyword`: 빈 값, 100자 초과, trim 처리)
+2. 사용자가 속한 팀 목록 조회 (`member_team`)
+3. 팀 정보 조회 (팀명 매핑)
+4. 해당 팀들의 회고 중 키워드 포함 회고 검색 (`LIKE '%keyword%'`)
+5. 결과를 `start_time DESC`, `retrospect_id DESC` 정렬 (안정 정렬)
+6. `start_time`은 생성 시 KST로 저장되므로 변환 없이 직접 포맷
+
+### 정렬 기준
+- 1차: `start_time` 내림차순 (최신순)
+- 2차: `retrospect_id` 내림차순 (동일 시간대 안정 정렬)
+- DB 레벨에서 `start_time DESC, retrospect_id DESC`로 처리
+
+### 검증 규칙
+- 키워드 필수 (빈 문자열/공백만 불가)
+- 키워드 최대 100자 제한
+- 앞뒤 공백 자동 제거 (trim)
+
+## 테스트
+
+### DTO 테스트 (dto.rs)
+- `should_serialize_search_retrospect_item_in_camel_case` - camelCase 직렬화 검증
+- `should_serialize_search_response_with_all_retrospect_methods` - 모든 회고 방식 직렬화
+- `should_serialize_success_search_response_in_camel_case` - 성공 응답 직렬화
+- `should_serialize_empty_search_response` - 빈 결과 직렬화
+- `should_deserialize_search_query_params_with_keyword` - 키워드 파라미터 역직렬화
+- `should_fail_deserialize_search_query_params_without_keyword` - 키워드 누락 시 역직렬화 실패
+
+### 서비스 테스트 (service.rs)
+- `should_fail_when_keyword_is_empty` - 빈 키워드 → `SearchKeywordInvalid` 에러
+- `should_fail_when_keyword_exceeds_100_chars` - 100자 초과 → `SearchKeywordInvalid` 에러
+- `should_pass_when_keyword_is_exactly_100_chars` - 100자 경계값 통과
+- `should_fail_when_keyword_is_whitespace_only` - 공백만 → `SearchKeywordInvalid` 에러
+- `should_trim_keyword_with_leading_trailing_whitespace` - 앞뒤 공백 trim 후 반환
+- `should_pass_valid_keyword` - 정상 키워드 통과
+
+## 리뷰 후 개선사항
+
+### v2 개선 (리뷰 피드백 반영)
+1. **keyword 필수 파라미터화**: `Option<String>` → `String`으로 변경하여 OpenAPI 스키마와 서비스 로직의 기대치를 일치시킴
+2. **이중 KST 변환 버그 수정**: `start_time`은 생성 시 KST NaiveDateTime으로 저장되므로, 검색 및 상세 API에서 `+9시간` 변환을 제거 (이중 변환 방지)
+3. **검색 정렬 안정화**: `start_time DESC`에 `retrospect_id DESC` 보조 정렬 추가로 동일 시간대 레코드의 순서 보장
+4. **검색 테스트 보강**: 키워드 검증을 `validate_search_keyword` 함수로 추출하고, `AppError` 반환을 직접 검증하는 테스트로 교체
+
+## 코드 리뷰 체크리스트
+- [x] TDD 원칙을 따라 테스트 코드가 작성되었는가?
+- [x] 모든 테스트가 통과하는가? (101 passed)
+- [x] API 문서가 `docs/reviews/` 디렉토리에 작성되었는가?
+- [x] 공통 유틸리티를 재사용했는가? (BaseResponse, AppError, AuthUser)
+- [x] 에러 처리가 적절하게 되어 있는가? (SEARCH4001, AUTH4001, COMMON500)
+- [x] 코드가 Rust 컨벤션을 따르는가? (cargo fmt, cargo clippy)
+- [x] 불필요한 의존성이 추가되지 않았는가?


### PR DESCRIPTION
## Summary

사용자가 참여하는 모든 팀의 회고를 **프로젝트명/회고명 기준으로 검색**하는 API를 구현했습니다.

### 주요 기능
- 프로젝트명/회고명 기반 키워드 검색 (LIKE 쿼리)
- 검색 키워드 검증 (필수, 1~100자, 앞뒤 공백 자동 trim)
- 사용자 소속 팀의 회고만 검색 (팀 멤버십 기반)
- 최신순 안정 정렬 (start_time DESC + retrospect_id DESC)
- start_time은 생성 시 KST로 저장되므로 이중 변환 없이 직접 포맷

---

## 브랜치 구조

> 이 PR은 dev 브랜치를 base로 합니다.

```
dev ← feature/api-023-retrospect-search (이 PR)
```

---

## 구현 내용

### 파일 변경 사항

| 파일 | 변경 유형 | 설명 |
|------|----------|------|
| `src/utils/error.rs` | 수정 | `SearchKeywordInvalid` 에러 variant 추가 (SEARCH4001, 400) |
| `src/domain/retrospect/dto.rs` | 수정 | `SearchQueryParams`, `SearchRetrospectItem`, `SuccessSearchResponse` DTO 추가 + 단위 테스트 6개 |
| `src/domain/retrospect/service.rs` | 수정 | `search_retrospects`, `validate_search_keyword` 비즈니스 로직 + 이중 KST 변환 수정 + 단위 테스트 6개 |
| `src/domain/retrospect/handler.rs` | 수정 | `search_retrospects` 핸들러 + Swagger 문서화 |
| `src/main.rs` | 수정 | 라우트 등록 + OpenAPI 스키마/경로 추가 |
| `docs/reviews/api-023-retrospect-search.md` | 신규 | 구현 리뷰 문서 |

### API 스펙

**엔드포인트**: `GET /api/v1/retrospects/search`

**Query Parameter**:
| 필드 | 타입 | 필수 | 설명 |
|------|------|------|------|
| `keyword` | string | Y | 검색 키워드 (1~100자) |

**Success Response (200)**:
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "검색을 성공했습니다.",
  "result": [
    {
      "retrospectId": 42,
      "projectName": "스프린트 회고",
      "teamName": "팀A",
      "retrospectMethod": "KPT",
      "retrospectDate": "2026-01-24",
      "retrospectTime": "14:30"
    }
  ]
}
```

### 에러 코드

| 코드 | HTTP | 발생 조건 |
|------|------|----------|
| `SEARCH4001` | 400 | 검색어 누락 또는 유효하지 않음 (빈 문자열, 100자 초과) |
| `AUTH4001` | 401 | 인증 실패 |
| `COMMON500` | 500 | 서버 내부 오류 |

### 비즈니스 로직 흐름

```
1. 키워드 검증 (validate_search_keyword: 빈 값, 100자 초과, trim 처리)
2. 사용자가 속한 팀 목록 조회 (member_team)
3. 팀 정보 조회 (팀명 매핑용 HashMap)
4. 해당 팀들의 회고 중 title에 키워드가 포함된 회고 검색
5. start_time DESC + retrospect_id DESC 정렬 (안정 정렬)
6. 응답 DTO 변환 (start_time → date/time 분리 포맷)
```

---

## Test Plan

### 테스트 현황

- ✅ **단위 테스트**: 101개 통과 (기존 89개 + API-023 DTO 6개 + 서비스 6개)
- ✅ **통합 테스트**: 37개 통과
- ✅ **총 138개 테스트 모두 통과**

### API-023 DTO 테스트 (6개) - dto.rs

| 테스트 | 검증 내용 |
|--------|----------|
| `should_serialize_search_retrospect_item_in_camel_case` | camelCase 직렬화 + snake_case 키 부재 확인 |
| `should_serialize_search_response_with_all_retrospect_methods` | 모든 RetrospectMethod 직렬화 (KPT, FOUR_L, FIVE_F, PMI, FREE) |
| `should_serialize_success_search_response_in_camel_case` | 전체 Swagger 응답 직렬화 검증 |
| `should_serialize_empty_search_response` | 빈 결과 배열 직렬화 |
| `should_deserialize_search_query_params_with_keyword` | keyword 파라미터 역직렬화 |
| `should_fail_deserialize_search_query_params_without_keyword` | keyword 누락 시 역직렬화 실패 |

### API-023 서비스 테스트 (6개) - service.rs

| 테스트 | 검증 내용 | 예상 결과 |
|--------|----------|----------|
| `should_fail_when_keyword_is_empty` | 빈 키워드 | Err(SearchKeywordInvalid) |
| `should_fail_when_keyword_exceeds_100_chars` | 101자 | Err(SearchKeywordInvalid) |
| `should_pass_when_keyword_is_exactly_100_chars` | 100자 경계값 | Ok |
| `should_fail_when_keyword_is_whitespace_only` | 공백만 입력 | Err(SearchKeywordInvalid) |
| `should_trim_keyword_with_leading_trailing_whitespace` | 앞뒤 공백 trim | Ok("스프린트") |
| `should_pass_valid_keyword` | 정상 키워드 | Ok("스프린트 회고") |

### 코드 품질 검사

- [x] `cargo test` - 138개 테스트 통과
- [x] `cargo clippy -- -D warnings` - 경고 없음
- [x] `cargo fmt` - 포맷팅 적용

---

## 설계 결정 및 Trade-offs

### 1. 검색 범위 (사용자 소속 팀 기반)
- **결정**: member_team 테이블에서 사용자가 속한 팀의 회고만 검색
- **이유**: 다른 팀의 회고 정보 노출 방지
- **Trade-off**: 팀 수가 많은 경우 IN 절이 커질 수 있음

### 2. 검색 방식 (LIKE 쿼리)
- **결정**: `title LIKE '%keyword%'` SQL 패턴 검색
- **이유**: 구현 단순성 + 현재 데이터 규모에 적합
- **Trade-off**: 대규모 데이터에서 Full Table Scan 가능, 필요시 Full-Text Search로 전환 고려

### 3. 정렬 안정화 (ID 보조 정렬)
- **결정**: `start_time DESC, retrospect_id DESC` 복합 정렬
- **이유**: 동일 시간대 레코드의 순서가 매 호출마다 달라지는 것 방지
- **Trade-off**: 약간의 정렬 비용 추가 (무시 가능)

### 4. KST 이중 변환 수정
- **결정**: start_time은 생성 시 KST NaiveDateTime으로 저장되므로 변환 제거
- **적용 범위**: search_retrospects (신규) + get_retrospect_detail (기존 수정)
- **이유**: +9시간 이중 적용으로 잘못된 날짜가 표시되는 버그 방지

---

## 리뷰 포인트

1. **검색 성능** - LIKE 쿼리의 현재 데이터 규모 대비 적합성
2. **키워드 검증** - 필수 파라미터 + 100자 제한의 적절성
3. **정렬 안정성** - retrospect_id 보조 정렬의 적합성
4. **KST 변환 수정** - get_retrospect_detail에서의 이중 변환 제거가 기존 동작에 영향 없는지

---

## 참고 문서

- 구현 리뷰: `docs/reviews/api-023-retrospect-search.md`
- 아키텍처 가이드: `docs/ai-conventions/architecture.md`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality for retrospects with keyword-based filtering across your teams
  * Search results display project name, team name, retrospect method, date, and time
  * Keyword validation enforces non-empty input with a maximum 100-character length limit

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->