### PR TITLE
feat: 로그아웃/토큰 갱신 API 및 Refresh Token DB 저장 구현

### DIFF
--- a/codes/server/src/config/app_config.rs
+++ b/codes/server/src/config/app_config.rs
@@ -7,6 +7,7 @@ pub struct AppConfig {
     pub server_port: u16,
     pub jwt_secret: String,
     pub jwt_expiration: i64,
+    pub refresh_token_expiration: i64,
 
     // Social Login (향후 소셜 로그인 기능에서 사용)
     pub google_client_id: String,
@@ -38,6 +39,11 @@ impl AppConfig {
             .parse()
             .map_err(|_| ConfigError::InvalidExpiration)?;
 
+        let refresh_token_expiration = env::var("REFRESH_TOKEN_EXPIRATION")
+            .unwrap_or_else(|_| "604800".to_string()) // 기본 7일
+            .parse()
+            .map_err(|_| ConfigError::InvalidExpiration)?;
+
         let google_client_id = env::var("GOOGLE_CLIENT_ID").unwrap_or_default();
         let google_redirect_uri = env::var("GOOGLE_REDIRECT_URI").unwrap_or_default();
         let kakao_client_id = env::var("KAKAO_CLIENT_ID").unwrap_or_default();
@@ -53,6 +59,7 @@ impl AppConfig {
             server_port,
             jwt_secret,
             jwt_expiration,
+            refresh_token_expiration,
             google_client_id,
             google_redirect_uri,
             kakao_client_id,

--- a/codes/server/src/domain/auth/dto.rs
+++ b/codes/server/src/domain/auth/dto.rs
@@ -24,6 +24,7 @@ pub struct EmailLoginRequest {
 #[serde(rename_all = "camelCase")]
 pub struct LoginResponse {
     pub access_token: String,
+    pub refresh_token: String,
     pub token_type: String,
     pub expires_in: i64,
 }
@@ -35,4 +36,50 @@ pub struct SuccessLoginResponse {
     pub code: String,
     pub message: String,
     pub result: LoginResponse,
+}
+
+/// 로그아웃 요청 DTO
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LogoutRequest {
+    /// 무효화할 Refresh Token
+    #[validate(length(min = 1, message = "refreshToken은 필수입니다"))]
+    pub refresh_token: String,
+}
+
+/// 토큰 갱신 요청 DTO
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenRefreshRequest {
+    /// 갱신에 사용할 Refresh Token
+    #[validate(length(min = 1, message = "refreshToken은 필수입니다"))]
+    pub refresh_token: String,
+}
+
+/// 토큰 갱신 응답 DTO
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenRefreshResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+}
+
+/// Swagger용 토큰 갱신 성공 응답 타입
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuccessTokenRefreshResponse {
+    pub is_success: bool,
+    pub code: String,
+    pub message: String,
+    pub result: TokenRefreshResponse,
+}
+
+/// Swagger용 로그아웃 성공 응답 타입
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuccessLogoutResponse {
+    pub is_success: bool,
+    pub code: String,
+    pub message: String,
+    pub result: Option<()>,
 }

--- a/codes/server/src/domain/member/entity/mod.rs
+++ b/codes/server/src/domain/member/entity/mod.rs
@@ -2,3 +2,4 @@ pub mod member;
 pub mod member_response;
 pub mod member_retro;
 pub mod member_retro_room;
+pub mod refresh_token;

--- a/codes/server/src/domain/member/entity/refresh_token.rs
+++ b/codes/server/src/domain/member/entity/refresh_token.rs
@@ -1,0 +1,33 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "refresh_token")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub refresh_token_id: i64,
+    pub member_id: i64,
+    pub token: String,
+    pub expires_at: DateTime,
+    pub created_at: DateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::member::Entity",
+        from = "Column::MemberId",
+        to = "super::member::Column::MemberId",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Member,
+}
+
+impl Related<super::member::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Member.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/codes/server/src/main.rs
+++ b/codes/server/src/main.rs
@@ -14,7 +14,8 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::config::AppConfig;
 use crate::domain::auth::dto::{
-    EmailLoginRequest, LoginRequest, LoginResponse, SuccessLoginResponse,
+    EmailLoginRequest, LoginRequest, LoginResponse, LogoutRequest, SuccessLoginResponse,
+    SuccessLogoutResponse, SuccessTokenRefreshResponse, TokenRefreshRequest, TokenRefreshResponse,
 };
 use crate::domain::member::entity::member_retro::RetrospectStatus;
 use crate::domain::retrospect::dto::{
@@ -40,6 +41,8 @@ use crate::utils::{BaseResponse, ErrorResponse};
         domain::auth::handler::login,
         domain::auth::handler::login_by_email,
         domain::auth::handler::auth_test,
+        domain::auth::handler::logout,
+        domain::auth::handler::refresh,
         domain::retrospect::handler::create_retrospect,
         domain::retrospect::handler::list_team_retrospects,
         domain::retrospect::handler::create_participant,
@@ -59,6 +62,11 @@ use crate::utils::{BaseResponse, ErrorResponse};
             LoginResponse,
             EmailLoginRequest,
             SuccessLoginResponse,
+            LogoutRequest,
+            SuccessLogoutResponse,
+            TokenRefreshRequest,
+            TokenRefreshResponse,
+            SuccessTokenRefreshResponse,
             CreateRetrospectRequest,
             CreateRetrospectResponse,
             SuccessCreateRetrospectResponse,
@@ -172,6 +180,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route(
             "/api/auth/test",
             axum::routing::get(domain::auth::handler::auth_test),
+        )
+        .route(
+            "/api/auth/logout",
+            axum::routing::post(domain::auth::handler::logout),
+        )
+        .route(
+            "/api/auth/refresh",
+            axum::routing::post(domain::auth::handler::refresh),
         )
         .route(
             "/api/v1/retrospects",

--- a/codes/server/src/utils/auth.rs
+++ b/codes/server/src/utils/auth.rs
@@ -4,7 +4,7 @@ use axum::{
 
 use crate::state::AppState;
 use crate::utils::error::AppError;
-use crate::utils::jwt::{decode_token, Claims};
+use crate::utils::jwt::{decode_access_token, Claims};
 
 /// 인증된 사용자 정보를 담는 Extractor
 pub struct AuthUser(pub Claims);
@@ -38,8 +38,8 @@ impl FromRequestParts<AppState> for AuthUser {
         // 토큰 추출
         let token = &auth_header_str[7..];
 
-        // 토큰 검증 및 디코딩
-        let claims = decode_token(token, &state.config.jwt_secret)?;
+        // 토큰 검증 및 디코딩 (Access Token만 허용)
+        let claims = decode_access_token(token, &state.config.jwt_secret)?;
 
         Ok(AuthUser(claims))
     }

--- a/codes/server/src/utils/jwt.rs
+++ b/codes/server/src/utils/jwt.rs
@@ -13,13 +13,17 @@ pub struct Claims {
     pub iat: usize,
     /// Expiration
     pub exp: usize,
+    /// Token Type ("access" or "refresh")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_type: Option<String>,
 }
 
-/// JWT 토큰 생성
-pub fn encode_token(
+/// JWT 토큰 생성 (token_type 포함)
+pub fn encode_token_with_type(
     sub: String,
     secret: &str,
     expiration_seconds: i64,
+    token_type: &str,
 ) -> Result<String, AppError> {
     let expiration = Utc::now()
         .checked_add_signed(Duration::seconds(expiration_seconds))
@@ -30,6 +34,7 @@ pub fn encode_token(
         sub,
         iat: Utc::now().timestamp() as usize,
         exp: expiration,
+        token_type: Some(token_type.to_string()),
     };
 
     encode(
@@ -38,6 +43,34 @@ pub fn encode_token(
         &EncodingKey::from_secret(secret.as_bytes()),
     )
     .map_err(|e| AppError::InternalError(format!("Token creation failed: {}", e)))
+}
+
+/// JWT 토큰 생성 (기존 호환용 - access 타입)
+#[allow(dead_code)]
+pub fn encode_token(
+    sub: String,
+    secret: &str,
+    expiration_seconds: i64,
+) -> Result<String, AppError> {
+    encode_token_with_type(sub, secret, expiration_seconds, "access")
+}
+
+/// Access Token 생성
+pub fn encode_access_token(
+    sub: String,
+    secret: &str,
+    expiration_seconds: i64,
+) -> Result<String, AppError> {
+    encode_token_with_type(sub, secret, expiration_seconds, "access")
+}
+
+/// Refresh Token 생성
+pub fn encode_refresh_token(
+    sub: String,
+    secret: &str,
+    expiration_seconds: i64,
+) -> Result<String, AppError> {
+    encode_token_with_type(sub, secret, expiration_seconds, "refresh")
 }
 
 /// JWT 토큰 검증
@@ -56,6 +89,28 @@ pub fn decode_token(token: &str, secret: &str) -> Result<Claims, AppError> {
         }
         _ => AppError::Unauthorized("유효하지 않은 토큰입니다.".into()),
     })
+}
+
+/// Access Token 전용 검증 (token_type == "access" 확인)
+pub fn decode_access_token(token: &str, secret: &str) -> Result<Claims, AppError> {
+    let claims = decode_token(token, secret)?;
+    match claims.token_type.as_deref() {
+        Some("access") => Ok(claims),
+        _ => Err(AppError::Unauthorized(
+            "유효하지 않은 액세스 토큰입니다.".into(),
+        )),
+    }
+}
+
+/// Refresh Token 전용 검증 (token_type == "refresh" 확인)
+pub fn decode_refresh_token(token: &str, secret: &str) -> Result<Claims, AppError> {
+    let claims = decode_token(token, secret)?;
+    match claims.token_type.as_deref() {
+        Some("refresh") => Ok(claims),
+        _ => Err(AppError::Unauthorized(
+            "유효하지 않은 리프레시 토큰입니다.".into(),
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -78,6 +133,60 @@ mod tests {
     fn test_invalid_token() {
         let secret = "test_secret";
         let result = decode_token("invalid_token", secret);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_access_token_validation() {
+        let secret = "test_secret";
+        let sub = "user_123".to_string();
+        let expiration = 3600;
+
+        let token =
+            encode_access_token(sub.clone(), secret, expiration).expect("Token generation failed");
+        let claims = decode_access_token(&token, secret).expect("Token validation failed");
+
+        assert_eq!(claims.sub, sub);
+        assert_eq!(claims.token_type, Some("access".to_string()));
+    }
+
+    #[test]
+    fn test_refresh_token_validation() {
+        let secret = "test_secret";
+        let sub = "user_123".to_string();
+        let expiration = 3600;
+
+        let token =
+            encode_refresh_token(sub.clone(), secret, expiration).expect("Token generation failed");
+        let claims = decode_refresh_token(&token, secret).expect("Token validation failed");
+
+        assert_eq!(claims.sub, sub);
+        assert_eq!(claims.token_type, Some("refresh".to_string()));
+    }
+
+    #[test]
+    fn test_refresh_token_rejected_as_access() {
+        let secret = "test_secret";
+        let sub = "user_123".to_string();
+        let expiration = 3600;
+
+        let refresh_token =
+            encode_refresh_token(sub, secret, expiration).expect("Token generation failed");
+        let result = decode_access_token(&refresh_token, secret);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_access_token_rejected_as_refresh() {
+        let secret = "test_secret";
+        let sub = "user_123".to_string();
+        let expiration = 3600;
+
+        let access_token =
+            encode_access_token(sub, secret, expiration).expect("Token generation failed");
+        let result = decode_refresh_token(&access_token, secret);
+
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Refresh Token을 DB에 저장하여 실제 로그아웃 기능 구현
- 로그아웃 시 Refresh Token을 DB에서 삭제
- 토큰 갱신 시 Refresh Token Rotation 적용 (보안 강화)
- JWT token_type 검증으로 토큰 혼용 공격 방지

## Changes
- `refresh_token` Entity 추가 (SeaORM)
- `POST /api/auth/logout` - Refresh Token 무효화
- `POST /api/auth/refresh` - 토큰 갱신 (새 Access + Refresh Token 발급)
- `REFRESH_TOKEN_EXPIRATION` 환경변수 추가 (기본 7일)
- `AuthUser` extractor에서 access token만 허용

## Test plan
- [ ] 로그인 후 refresh_token이 응답에 포함되는지 확인
- [ ] 로그아웃 호출 후 동일 refresh_token으로 갱신 시 실패하는지 확인
- [ ] 토큰 갱신 시 새로운 access/refresh token이 발급되는지 확인
- [ ] refresh_token으로 인증 API 호출 시 거부되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login responses now include a refresh token for improved session management
  * New logout endpoint available for secure token invalidation
  * New token refresh endpoint enables session extension without re-authentication

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->