### PR TITLE
🔒 security: 8080 포트 외부 노출 제거

### DIFF
--- a/ci/terraform/security_groups.tf
+++ b/ci/terraform/security_groups.tf
@@ -34,14 +34,8 @@ resource "aws_security_group" "ec2" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Application Port (Rust server default)
-  ingress {
-    description = "Application port"
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # 8080 포트는 Nginx 리버스 프록시를 통해 내부에서만 접근
+  # 외부 노출 제거 (보안 강화)
 
   # Outbound
   egress {


### PR DESCRIPTION
## Summary
- Security Group에서 8080 포트 ingress 규칙 제거
- Nginx 리버스 프록시를 통해 내부에서만 8080 접근

## Changes
| Before | After |
|--------|-------|
| 22, 80, 443, 8080 열림 | 22, 80, 443만 열림 |

## Reason
- 8080 포트 직접 노출 시 Nginx 우회 가능
- 보안 강화를 위해 80/443만 외부에 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)