### PR TITLE
refactor: 소셜 로그인 redirect_uri를 프론트엔드에서 전달받도록 변경

### DIFF
--- a/codes/server/.env.example
+++ b/codes/server/.env.example
@@ -20,12 +20,11 @@ REFRESH_TOKEN_EXPIRATION=1209600
 SIGNUP_TOKEN_EXPIRATION=600
 
 # Social Login (Authorization Code Flow)
+# redirect_uri는 프론트엔드에서 요청 시 전달받습니다
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
-GOOGLE_REDIRECT_URI=http://localhost:3000/auth/google/callback
 KAKAO_CLIENT_ID=your_kakao_client_id
 KAKAO_CLIENT_SECRET=your_kakao_client_secret
-KAKAO_REDIRECT_URI=http://localhost:3000/auth/kakao/callback
 
 # AI Service
 OPENAI_API_KEY=your_openai_api_key_here

--- a/codes/server/src/config/app_config.rs
+++ b/codes/server/src/config/app_config.rs
@@ -13,10 +13,8 @@ pub struct AppConfig {
     // Social Login
     pub google_client_id: String,
     pub google_client_secret: String,
-    pub google_redirect_uri: String,
     pub kakao_client_id: String,
     pub kakao_client_secret: String,
-    pub kakao_redirect_uri: String,
 
     // AI Service
     pub openai_api_key: String,
@@ -65,7 +63,6 @@ impl AppConfig {
             }
             Err(_) => return Err(ConfigError::MissingGoogleClientSecret),
         };
-        let google_redirect_uri = env::var("GOOGLE_REDIRECT_URI").unwrap_or_default();
         let kakao_client_id = env::var("KAKAO_CLIENT_ID").unwrap_or_default();
         let kakao_client_secret = match env::var("KAKAO_CLIENT_SECRET") {
             Ok(v) => v,
@@ -75,7 +72,6 @@ impl AppConfig {
             }
             Err(_) => return Err(ConfigError::MissingKakaoClientSecret),
         };
-        let kakao_redirect_uri = env::var("KAKAO_REDIRECT_URI").unwrap_or_default();
 
         let openai_api_key = env::var("OPENAI_API_KEY").unwrap_or_else(|_| {
             tracing::warn!(
@@ -91,10 +87,8 @@ impl AppConfig {
             signup_token_expiration,
             google_client_id,
             google_client_secret,
-            google_redirect_uri,
             kakao_client_id,
             kakao_client_secret,
-            kakao_redirect_uri,
             openai_api_key,
         })
     }

--- a/codes/server/src/domain/auth/dto.rs
+++ b/codes/server/src/domain/auth/dto.rs
@@ -30,6 +30,10 @@ pub struct SocialLoginRequest {
     /// 소셜 서비스에서 발급받은 인가 코드 (Authorization Code)
     #[validate(length(min = 1, message = "code는 필수입니다"))]
     pub code: String,
+
+    /// 인가 코드 발급 시 사용한 리다이렉트 URI
+    #[validate(length(min = 1, message = "redirectUri는 필수입니다"))]
+    pub redirect_uri: String,
 }
 
 /// [API-001] 소셜 로그인 응답 DTO

--- a/codes/server/src/domain/auth/service.rs
+++ b/codes/server/src/domain/auth/service.rs
@@ -59,7 +59,7 @@ impl AuthService {
                     &req.code,
                     &state.config.kakao_client_id,
                     &state.config.kakao_client_secret,
-                    &state.config.kakao_redirect_uri,
+                    &req.redirect_uri,
                 )
                 .await?;
                 Self::fetch_kakao_user_info(&access_token).await?
@@ -69,7 +69,7 @@ impl AuthService {
                     &req.code,
                     &state.config.google_client_id,
                     &state.config.google_client_secret,
-                    &state.config.google_redirect_uri,
+                    &req.redirect_uri,
                 )
                 .await?;
                 Self::fetch_google_user_info(&access_token).await?


### PR DESCRIPTION
## Summary

- 소셜 로그인 API에서 `redirect_uri`를 환경변수가 아닌 프론트엔드 요청에서 전달받도록 변경
- `SocialLoginRequest` DTO에 `redirectUri` 필드 추가
- `AppConfig`에서 `google_redirect_uri`, `kakao_redirect_uri` 환경변수 제거

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `dto.rs` | `SocialLoginRequest`에 `redirect_uri` 필드 추가 |
| `app_config.rs` | `google_redirect_uri`, `kakao_redirect_uri` 필드 및 로딩 로직 제거 |
| `service.rs` | 환경변수 대신 `req.redirect_uri` 사용 |
| `.env.example` | `GOOGLE_REDIRECT_URI`, `KAKAO_REDIRECT_URI` 환경변수 제거 |

## API Request Example

```json
{
  "provider": "GOOGLE",
  "code": "인가_코드",
  "redirectUri": "http://localhost:3000/auth/google/callback"
}
```

## Test plan

- [x] `cargo build` 통과
- [x] `cargo clippy -- -D warnings` 경고 없음
- [x] `cargo test` 전체 테스트 통과

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated OAuth authentication to use dynamic redirect URIs provided at request time instead of static configuration, enabling greater flexibility for deployment scenarios.
  * Simplified application configuration by removing hardcoded OAuth redirect URI settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->