### PR TITLE
feat: 로그인된 유저 프로필 조회 API 추가

### DIFF
--- a/codes/server/src/domain/member/dto.rs
+++ b/codes/server/src/domain/member/dto.rs
@@ -1,7 +1,31 @@
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use super::entity::member::SocialType;
 use crate::utils::BaseResponse;
+
+/// 회원 프로필 응답
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberProfileResponse {
+    pub member_id: i64,
+    pub email: String,
+    pub nickname: Option<String>,
+    pub insight_count: i32,
+    pub social_type: SocialType,
+    pub created_at: DateTime<Utc>,
+}
+
+/// 회원 프로필 조회 성공 응답 (Swagger 문서용)
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuccessProfileResponse {
+    pub is_success: bool,
+    pub code: String,
+    pub message: String,
+    pub result: MemberProfileResponse,
+}
 
 /// 회원 탈퇴 성공 응답 (Swagger 문서용)
 #[derive(Debug, Serialize, ToSchema)]

--- a/codes/server/src/domain/member/handler.rs
+++ b/codes/server/src/domain/member/handler.rs
@@ -1,10 +1,38 @@
 use axum::{extract::State, Json};
 
+use super::dto::MemberProfileResponse;
 use super::service::MemberService;
 use crate::state::AppState;
 use crate::utils::auth::AuthUser;
 use crate::utils::error::AppError;
 use crate::utils::BaseResponse;
+
+/// 로그인된 유저 프로필 조회 API
+///
+/// JWT 토큰에서 사용자 정보를 추출하여 프로필을 반환합니다.
+#[utoipa::path(
+    get,
+    path = "/api/v1/members/me",
+    security(
+        ("bearer_auth" = [])
+    ),
+    responses(
+        (status = 200, description = "프로필 조회 성공", body = SuccessProfileResponse),
+        (status = 401, description = "인증 실패", body = ErrorResponse),
+        (status = 404, description = "존재하지 않는 사용자", body = ErrorResponse),
+        (status = 500, description = "서버 내부 오류", body = ErrorResponse)
+    ),
+    tag = "Member"
+)]
+pub async fn get_profile(
+    State(state): State<AppState>,
+    user: AuthUser,
+) -> Result<Json<BaseResponse<MemberProfileResponse>>, AppError> {
+    let member_id = user.user_id()?;
+    let profile = MemberService::get_profile(&state, member_id).await?;
+
+    Ok(Json(BaseResponse::success(profile)))
+}
 
 /// 서비스 탈퇴 API (API-025)
 ///

--- a/codes/server/src/domain/member/service.rs
+++ b/codes/server/src/domain/member/service.rs
@@ -1,6 +1,8 @@
+use chrono::{TimeZone, Utc};
 use sea_orm::EntityTrait;
 use tracing::info;
 
+use super::dto::MemberProfileResponse;
 use crate::domain::member::entity::member;
 use crate::state::AppState;
 use crate::utils::error::AppError;
@@ -8,6 +10,27 @@ use crate::utils::error::AppError;
 pub struct MemberService;
 
 impl MemberService {
+    /// 회원 프로필 조회
+    pub async fn get_profile(
+        state: &AppState,
+        member_id: i64,
+    ) -> Result<MemberProfileResponse, AppError> {
+        let member = member::Entity::find_by_id(member_id)
+            .one(&state.db)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?
+            .ok_or_else(|| AppError::MemberNotFound("존재하지 않는 사용자입니다.".to_string()))?;
+
+        Ok(MemberProfileResponse {
+            member_id: member.member_id,
+            email: member.email,
+            nickname: member.nickname,
+            insight_count: member.insight_count,
+            social_type: member.social_type,
+            created_at: Utc.from_utc_datetime(&member.created_at),
+        })
+    }
+
     /// 회원 탈퇴 처리
     ///
     /// 사용자 계정 정보를 삭제하고, 연관 데이터(답변, 회고 등)는 유지합니다.

--- a/codes/server/src/main.rs
+++ b/codes/server/src/main.rs
@@ -25,7 +25,9 @@ use crate::domain::auth::dto::{
     SuccessSignupResponse, SuccessSocialLoginResponse, SuccessTokenRefreshResponse,
     TokenRefreshRequest, TokenRefreshResponse,
 };
-use crate::domain::member::dto::SuccessWithdrawResponse;
+use crate::domain::member::dto::{
+    MemberProfileResponse, SuccessProfileResponse, SuccessWithdrawResponse,
+};
 use crate::domain::member::entity::member_retro::RetrospectStatus;
 use crate::domain::retrospect::dto::{
     AnalysisResponse, AssistantRequest, AssistantResponse, CommentItem, CreateCommentRequest,
@@ -90,6 +92,7 @@ use crate::utils::{BaseResponse, ErrorResponse};
         domain::retrospect::handler::toggle_like,
         domain::retrospect::handler::assistant_guide,
         // Member APIs
+        domain::member::handler::get_profile,
         domain::member::handler::withdraw
     ),
     components(
@@ -184,6 +187,8 @@ use crate::utils::{BaseResponse, ErrorResponse};
             GuideType,
             SuccessAssistantResponse,
             // Member DTOs
+            MemberProfileResponse,
+            SuccessProfileResponse,
             SuccessWithdrawResponse
         )
     ),
@@ -192,7 +197,8 @@ use crate::utils::{BaseResponse, ErrorResponse};
         (name = "Auth", description = "인증 API"),
         (name = "RetroRoom", description = "회고방 관리 API"),
         (name = "Retrospect", description = "회고 API"),
-        (name = "Response", description = "회고 답변 API")
+        (name = "Response", description = "회고 답변 API"),
+        (name = "Member", description = "회원 API")
     ),
     modifiers(&SecurityAddon),
     info(
@@ -396,6 +402,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route(
             "/api/v1/responses/:response_id/likes",
             axum::routing::post(domain::retrospect::handler::toggle_like),
+        )
+        // 로그인된 유저 프로필 조회
+        .route(
+            "/api/v1/members/me",
+            axum::routing::get(domain::member::handler::get_profile),
         )
         // [API-025] 서비스 탈퇴
         .route(


### PR DESCRIPTION
## Summary
- `GET /api/v1/members/me` 엔드포인트 추가
- JWT 토큰에서 사용자 ID를 추출하여 DB에서 프로필 조회
- 인증 실패 시 401, 사용자 없음 시 404 응답

## 변경사항
- `dto.rs`: `MemberProfileResponse`, `SuccessProfileResponse` 추가
- `service.rs`: `get_profile()` 메서드 추가
- `handler.rs`: `get_profile()` 핸들러 추가
- `main.rs`: 라우터 및 OpenAPI 문서 등록

## 응답 예시
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "memberId": 1,
    "email": "user@example.com",
    "nickname": "홍길동",
    "insightCount": 5,
    "socialType": "KAKAO",
    "createdAt": "2024-01-01T00:00:00Z"
  }
}
```

## Test plan
- [ ] 유효한 JWT로 프로필 조회 시 200 응답 확인
- [ ] 토큰 없이 요청 시 401 응답 확인
- [ ] 존재하지 않는 사용자 토큰으로 요청 시 404 응답 확인

Closes #98

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to retrieve authenticated user profile information via new API endpoint. Profile includes email, nickname, insight count, social type, and account creation date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->