### PR TITLE
fix: member_retro_room created_at 마이그레이션 추가

### DIFF
--- a/codes/server/src/config/database.rs
+++ b/codes/server/src/config/database.rs
@@ -99,6 +99,15 @@ async fn apply_migrations(db: &DatabaseConnection) -> Result<(), DbErr> {
     add_column_if_not_exists(db, "member", "refresh_token", "VARCHAR(500) NULL").await?;
     add_column_if_not_exists(db, "member", "refresh_token_expires_at", "DATETIME NULL").await?;
 
+    // Migration: Add created_at column to member_retro_room table
+    add_column_if_not_exists(
+        db,
+        "member_retro_room",
+        "created_at",
+        "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP",
+    )
+    .await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- 기존 `member_retro_room` 테이블에 `created_at` 컬럼이 없어서 회고방 관련 API에서 500 에러 발생
- `apply_migrations()` 함수에 마이그레이션 추가

## 원인
- 최근 커밋 `4561f43`에서 `created_at` 필드를 엔티티에 추가했으나 DB 마이그레이션이 누락됨
- 기존 테이블에 컬럼이 없어서 SeaORM 쿼리 실패

## 해결
```rust
add_column_if_not_exists(
    db,
    "member_retro_room",
    "created_at",
    "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP",
).await?;
```

## Test plan
- [x] `cargo build` 성공
- [x] `cargo test` 전체 통과
- [x] `cargo clippy -- -D warnings` 경고 없음
- [ ] 배포 후 회고방 API 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated database schema to add timestamp tracking for member participation in retrospective sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->