### PR TITLE
fix: 회고 생성 API에서 retrospectTime 필드 제거

### DIFF
--- a/codes/server/src/domain/retrospect/dto.rs
+++ b/codes/server/src/domain/retrospect/dto.rs
@@ -215,7 +215,6 @@ pub struct RetrospectListItem {
     pub project_name: String,
     pub retrospect_method: String,
     pub retrospect_date: String,
-    pub retrospect_time: String,
     /// 해당 회고의 참여자 수
     pub participant_count: i64,
 }
@@ -283,14 +282,6 @@ pub struct CreateRetrospectRequest {
         message = "날짜 형식이 올바르지 않습니다. (YYYY-MM-DD 형식 필요)"
     ))]
     pub retrospect_date: String,
-
-    /// 회고 시간 (HH:mm 형식, 한국 시간 기준)
-    #[validate(length(
-        min = 5,
-        max = 5,
-        message = "시간 형식이 올바르지 않습니다. (HH:mm 형식 필요)"
-    ))]
-    pub retrospect_time: String,
 
     /// 회고 방식
     pub retrospect_method: RetrospectMethod,
@@ -744,8 +735,6 @@ pub struct SearchRetrospectItem {
     pub retrospect_method: RetrospectMethod,
     /// 회고 날짜 (YYYY-MM-DD)
     pub retrospect_date: String,
-    /// 회고 시간 (HH:mm)
-    pub retrospect_time: String,
 }
 
 /// Swagger용 회고 검색 성공 응답 타입
@@ -1072,7 +1061,6 @@ mod tests {
             retro_room_id: 1,
             project_name: "테스트 프로젝트".to_string(),
             retrospect_date: "2025-01-25".to_string(),
-            retrospect_time: "14:00".to_string(),
             retrospect_method: RetrospectMethod::Kpt,
             reference_urls: vec![],
             questions: vec!["테스트 질문 1".to_string(), "테스트 질문 2".to_string()],
@@ -1327,61 +1315,6 @@ mod tests {
         let valid_url = format!("https://example.com/{}", "a".repeat(2020));
         let request = CreateRetrospectRequest {
             reference_urls: vec![valid_url],
-            ..create_valid_request()
-        };
-
-        // Act
-        let result = request.validate();
-
-        // Assert
-        assert!(result.is_ok());
-    }
-
-    // ========================================
-    // retrospect_time 검증 테스트
-    // ========================================
-
-    #[test]
-    fn should_fail_validation_when_retrospect_time_is_too_short() {
-        // Arrange
-        let request = CreateRetrospectRequest {
-            retrospect_time: "9:00".to_string(), // 4자 (형식 오류)
-            ..create_valid_request()
-        };
-
-        // Act
-        let result = request.validate();
-
-        // Assert
-        assert!(result.is_err());
-        let errors = result.unwrap_err();
-        let field_errors = errors.field_errors();
-        assert!(field_errors.contains_key("retrospect_time"));
-    }
-
-    #[test]
-    fn should_fail_validation_when_retrospect_time_is_too_long() {
-        // Arrange
-        let request = CreateRetrospectRequest {
-            retrospect_time: "14:00:00".to_string(), // 8자 (형식 오류)
-            ..create_valid_request()
-        };
-
-        // Act
-        let result = request.validate();
-
-        // Assert
-        assert!(result.is_err());
-        let errors = result.unwrap_err();
-        let field_errors = errors.field_errors();
-        assert!(field_errors.contains_key("retrospect_time"));
-    }
-
-    #[test]
-    fn should_pass_validation_when_retrospect_time_has_correct_format() {
-        // Arrange
-        let request = CreateRetrospectRequest {
-            retrospect_time: "14:30".to_string(), // 정확히 5자
             ..create_valid_request()
         };
 
@@ -1793,7 +1726,6 @@ mod tests {
             retro_room_name: "회고방A".to_string(),
             retrospect_method: RetrospectMethod::Kpt,
             retrospect_date: "2026-01-24".to_string(),
-            retrospect_time: "14:30".to_string(),
         };
 
         // Act
@@ -1805,14 +1737,12 @@ mod tests {
         assert_eq!(json["retroRoomName"], "회고방A");
         assert_eq!(json["retrospectMethod"], "KPT");
         assert_eq!(json["retrospectDate"], "2026-01-24");
-        assert_eq!(json["retrospectTime"], "14:30");
         // snake_case 키가 없는지 확인
         assert!(json.get("retrospect_id").is_none());
         assert!(json.get("project_name").is_none());
         assert!(json.get("retro_room_name").is_none());
         assert!(json.get("retrospect_method").is_none());
         assert!(json.get("retrospect_date").is_none());
-        assert!(json.get("retrospect_time").is_none());
     }
 
     #[test]
@@ -1833,7 +1763,6 @@ mod tests {
                 retro_room_name: "회고방".to_string(),
                 retrospect_method: method,
                 retrospect_date: "2026-01-01".to_string(),
-                retrospect_time: "10:00".to_string(),
             };
 
             let json = serde_json::to_value(&item).unwrap();
@@ -1854,7 +1783,6 @@ mod tests {
                 retro_room_name: "회고방A".to_string(),
                 retrospect_method: RetrospectMethod::Kpt,
                 retrospect_date: "2026-01-24".to_string(),
-                retrospect_time: "14:00".to_string(),
             }],
         };
 

--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -794,7 +794,6 @@ impl RetrospectService {
                     project_name: r.title,
                     retrospect_method: r.retrospect_method.to_string(),
                     retrospect_date: r.start_time.format("%Y-%m-%d").to_string(),
-                    retrospect_time: r.start_time.format("%H:%M").to_string(),
                     participant_count,
                 }
             })
@@ -881,12 +880,8 @@ impl RetrospectService {
         // 1. 참고 URL 검증
         Self::validate_reference_urls(&req.reference_urls)?;
 
-        // 2. 날짜 및 시간 형식 검증
+        // 2. 날짜 형식 검증
         let retrospect_date = Self::validate_and_parse_date(&req.retrospect_date)?;
-        let retrospect_time = Self::validate_and_parse_time(&req.retrospect_time)?;
-
-        // 3. 미래 날짜/시간 검증
-        Self::validate_future_datetime(retrospect_date, retrospect_time)?;
 
         // 4. 회고방 존재 여부 확인
         let room_exists = RetroRoom::find_by_id(req.retro_room_id)
@@ -924,7 +919,8 @@ impl RetrospectService {
         let now = Utc::now().naive_utc();
 
         // 7. 회고 생성
-        let start_time = NaiveDateTime::new(retrospect_date, retrospect_time);
+        let default_time = NaiveTime::from_hms_opt(0, 0, 0).unwrap_or_default();
+        let start_time = NaiveDateTime::new(retrospect_date, default_time);
 
         // 질문 목록을 JSON으로 직렬화
         let questions_json = serde_json::to_string(&req.questions)
@@ -1037,30 +1033,6 @@ impl RetrospectService {
         }
 
         Ok(date)
-    }
-
-    /// 시간 형식 검증
-    fn validate_and_parse_time(time_str: &str) -> Result<NaiveTime, AppError> {
-        // HH:mm 형식 파싱
-        NaiveTime::parse_from_str(time_str, "%H:%M").map_err(|_| {
-            AppError::BadRequest("시간 형식이 올바르지 않습니다. (HH:mm 형식 필요)".to_string())
-        })
-    }
-
-    /// 미래 날짜/시간 검증 (한국 시간 기준, UTC+9)
-    fn validate_future_datetime(date: NaiveDate, time: NaiveTime) -> Result<(), AppError> {
-        let input_datetime = NaiveDateTime::new(date, time);
-
-        // 한국 시간 기준 현재 시각 (UTC + 9시간)
-        let now_kst = Utc::now().naive_utc() + chrono::Duration::hours(9);
-
-        if input_datetime <= now_kst {
-            return Err(AppError::BadRequest(
-                "회고 날짜와 시간은 현재보다 미래여야 합니다.".to_string(),
-            ));
-        }
-
-        Ok(())
     }
 
     /// 회고 모델에서 저장된 질문 목록을 추출합니다.
@@ -1881,7 +1853,6 @@ impl RetrospectService {
                     .unwrap_or_default(),
                 retrospect_method: r.retrospect_method.clone(),
                 retrospect_date: r.start_time.format("%Y-%m-%d").to_string(),
-                retrospect_time: r.start_time.format("%H:%M").to_string(),
             })
             .collect();
 
@@ -3827,107 +3798,6 @@ mod tests {
         // Assert
         assert!(result.is_err());
         assert!(matches!(result, Err(AppError::BadRequest(_))));
-    }
-
-    // ===== 시간 형식 검증 테스트 =====
-
-    #[test]
-    fn should_pass_valid_time_format() {
-        // Arrange
-        let valid_time = "14:30";
-
-        // Act
-        let result = RetrospectService::validate_and_parse_time(valid_time);
-
-        // Assert
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn should_pass_midnight_time() {
-        // Arrange
-        let midnight = "00:00";
-
-        // Act
-        let result = RetrospectService::validate_and_parse_time(midnight);
-
-        // Assert
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn should_pass_end_of_day_time() {
-        // Arrange
-        let end_of_day = "23:59";
-
-        // Act
-        let result = RetrospectService::validate_and_parse_time(end_of_day);
-
-        // Assert
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn should_fail_for_invalid_time_format() {
-        // Arrange
-        let invalid_time = "1430"; // 콜론 없는 형식
-
-        // Act
-        let result = RetrospectService::validate_and_parse_time(invalid_time);
-
-        // Assert
-        assert!(result.is_err());
-        if let Err(AppError::BadRequest(msg)) = result {
-            assert!(msg.contains("HH:mm"));
-        } else {
-            panic!("Expected BadRequest error");
-        }
-    }
-
-    #[test]
-    fn should_fail_for_invalid_time_value() {
-        // Arrange
-        let invalid_time = "25:00"; // 유효하지 않은 시간
-
-        // Act
-        let result = RetrospectService::validate_and_parse_time(invalid_time);
-
-        // Assert
-        assert!(result.is_err());
-        assert!(matches!(result, Err(AppError::BadRequest(_))));
-    }
-
-    // ===== 미래 날짜/시간 검증 테스트 =====
-
-    #[test]
-    fn should_pass_future_datetime() {
-        // Arrange
-        let future_date = Utc::now().date_naive() + chrono::Duration::days(7);
-        let time = NaiveTime::from_hms_opt(14, 0, 0).unwrap();
-
-        // Act
-        let result = RetrospectService::validate_future_datetime(future_date, time);
-
-        // Assert
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn should_fail_for_past_datetime() {
-        // Arrange
-        let past_date = NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
-        let time = NaiveTime::from_hms_opt(14, 0, 0).unwrap();
-
-        // Act
-        let result = RetrospectService::validate_future_datetime(past_date, time);
-
-        // Assert
-        assert!(result.is_err());
-        if let Err(AppError::BadRequest(msg)) = result {
-            assert!(msg.contains("미래"));
-        } else {
-            panic!("Expected BadRequest error");
-        }
     }
 
     // ===== RetrospectMethod 기본 질문 테스트 =====

--- a/codes/server/tests/api_010_retro_room_retrospects_test.rs
+++ b/codes/server/tests/api_010_retro_room_retrospects_test.rs
@@ -17,7 +17,6 @@ fn should_serialize_retrospect_list_item_in_camel_case() {
         project_name: "프로젝트".to_string(),
         retrospect_method: "KPT".to_string(),
         retrospect_date: "2026-01-26".to_string(),
-        retrospect_time: "10:00".to_string(),
         participant_count: 5,
     };
 
@@ -30,7 +29,6 @@ fn should_serialize_retrospect_list_item_in_camel_case() {
     assert!(parsed.get("projectName").is_some());
     assert!(parsed.get("retrospectMethod").is_some());
     assert!(parsed.get("retrospectDate").is_some());
-    assert!(parsed.get("retrospectTime").is_some());
     assert!(parsed.get("participantCount").is_some());
     assert_eq!(parsed["retrospectId"], 1);
     assert_eq!(parsed["projectName"], "프로젝트");
@@ -71,7 +69,6 @@ fn should_serialize_list_with_multiple_retrospects() {
                 project_name: "프로젝트1".to_string(),
                 retrospect_method: "KPT".to_string(),
                 retrospect_date: "2026-01-26".to_string(),
-                retrospect_time: "10:00".to_string(),
                 participant_count: 3,
             },
             RetrospectListItem {
@@ -79,7 +76,6 @@ fn should_serialize_list_with_multiple_retrospects() {
                 project_name: "프로젝트2".to_string(),
                 retrospect_method: "FOUR_L".to_string(),
                 retrospect_date: "2026-01-27".to_string(),
-                retrospect_time: "14:00".to_string(),
                 participant_count: 5,
             },
         ],
@@ -108,7 +104,6 @@ fn should_preserve_retrospect_method_values() {
             project_name: "테스트".to_string(),
             retrospect_method: method.to_string(),
             retrospect_date: "2026-01-26".to_string(),
-            retrospect_time: "10:00".to_string(),
             participant_count: 2,
         };
 
@@ -128,7 +123,6 @@ fn should_preserve_date_format() {
         project_name: "테스트".to_string(),
         retrospect_method: "KPT".to_string(),
         retrospect_date: "2026-12-31".to_string(),
-        retrospect_time: "23:59".to_string(),
         participant_count: 4,
     };
 
@@ -137,5 +131,4 @@ fn should_preserve_date_format() {
 
     // Assert
     assert!(json.contains("2026-12-31"));
-    assert!(json.contains("23:59"));
 }

--- a/docs/api-specs/012-retrospect-create.md
+++ b/docs/api-specs/012-retrospect-create.md
@@ -15,6 +15,7 @@
 | 1.2.0 | 2025-01-25 | teamId 필드 추가, 날짜 포맷 ISO 8601(YYYY-MM-DD) 통일, 질문 생성 로직 추가 |
 | 1.3.0 | 2026-01-30 | teamId → retroRoomId로 변경, retrospectTime 필드 추가 (실제 구현과 동기화) |
 | 2.0.0 | 2026-02-20 | questions 필드 추가 (필수), 서버 기본 질문 생성 로직 제거, 클라이언트가 질문을 직접 전달 |
+| 2.1.0 | 2026-02-20 | retrospectTime 필드 제거 (더 이상 시간을 입력받지 않음) |
 
 ## 엔드포인트
 
@@ -42,7 +43,6 @@ POST /api/v1/retrospects
   "retroRoomId": 789,
   "projectName": "나만의 회고 플랫폼",
   "retrospectDate": "2026-01-24",
-  "retrospectTime": "14:00",
   "retrospectMethod": "KPT",
   "referenceUrls": [
     "https://github.com/jayson/project",
@@ -63,7 +63,6 @@ POST /api/v1/retrospects
 | retroRoomId | long | Yes | 회고가 속한 회고방의 고유 ID | 1 이상의 양수 |
 | projectName | string | Yes | 프로젝트 이름 | 최소 1자, 최대 20자 |
 | retrospectDate | string | Yes | 회고 날짜 | ISO 8601 형식 (YYYY-MM-DD) |
-| retrospectTime | string | Yes | 회고 시간 (한국 시간 기준) | HH:mm 형식 (예: 14:00) |
 | retrospectMethod | string (Enum) | Yes | 회고 방식 | KPT, FOUR_L, FIVE_F, PMI, FREE 중 하나 |
 | referenceUrls | array[string] | No | 참고 자료 URL 리스트 | 최대 10개, 각 URL은 유효한 형식이어야 함 (http/https) |
 | questions | array[string] | Yes | 회고 질문 목록 | 최소 1개, 각 질문은 빈 문자열 불가 |
@@ -231,7 +230,7 @@ POST /api/v1/retrospects
 | COMMON400 | 400 | 질문 목록 유효성 검사 실패 | questions가 비어있거나, 빈 문자열 질문 포함 |
 | RETRO4005 | 400 | 유효하지 않은 회고 방식 | retrospectMethod가 정의된 Enum 외의 값 |
 | RETRO4006 | 400 | 유효하지 않은 URL 형식 | referenceUrls 중 http/https가 아닌 URL 포함 |
-| COMMON400 | 400 | 잘못된 요청 | 날짜/시간 형식 오류(YYYY-MM-DD, HH:mm), 필수 필드 누락 등 |
+| COMMON400 | 400 | 잘못된 요청 | 날짜 형식 오류(YYYY-MM-DD), 필수 필드 누락 등 |
 | AUTH4001 | 401 | 인증 정보가 유효하지 않음 | 토큰 누락, 만료, 또는 잘못된 형식 |
 | RETRO4031 | 403 | 회고방 접근 권한 없음 | 해당 회고방의 멤버가 아닌 경우 |
 | RETRO4041 | 404 | 존재하지 않는 회고방 | 유효하지 않은 retroRoomId |
@@ -249,7 +248,6 @@ curl -X POST https://api.example.com/api/v1/retrospects \
     "retroRoomId": 789,
     "projectName": "나만의 회고 플랫폼",
     "retrospectDate": "2026-01-24",
-    "retrospectTime": "14:00",
     "retrospectMethod": "KPT",
     "referenceUrls": [
       "https://github.com/jayson/project",

--- a/docs/reviews/012-retrospect-create.md
+++ b/docs/reviews/012-retrospect-create.md
@@ -336,7 +336,6 @@ curl -X POST http://localhost:8080/api/v1/retrospects \
     "retroRoomId": 789,
     "projectName": "나만의 회고 플랫폼",
     "retrospectDate": "2026-02-25",
-    "retrospectTime": "14:00",
     "retrospectMethod": "KPT",
     "referenceUrls": [],
     "questions": [


### PR DESCRIPTION
## Summary
- 회고 생성 API(`POST /api/v1/retrospects`)에서 `retrospectTime` 필드를 제거했습니다
- 더 이상 회고 시간을 입력받지 않으며, 내부적으로 기본값(00:00:00)을 사용합니다
- 회고 목록 조회 및 검색 응답에서도 `retrospectTime` 필드를 제거했습니다

## Changes
- `CreateRetrospectRequest`에서 `retrospect_time` 필드 제거
- `RetrospectListItem`, `SearchRetrospectItem`에서 `retrospect_time` 제거
- `validate_and_parse_time`, `validate_future_datetime` 함수 제거
- 관련 테스트 10개 제거 (시간 포맷 검증 5개, 미래 시간 검증 2개, 직렬화 3개)
- API 스펙 v2.1.0으로 업데이트
- 리뷰 문서 업데이트

## Test plan
- [x] `cargo test` 전체 통과 (392개)
- [x] `cargo clippy -- -D warnings` 경고 없음
- [x] `cargo fmt` 적용 완료
- [x] `retrospectTime` 없이 회고 생성 요청 정상 동작 확인

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the time field from retrospectives. The system now uses a fixed time (00:00) instead of allowing custom time entries.

* **Bug Fixes**
  * Simplified retrospective creation by removing time validation, reducing configuration complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->