### PR TITLE
feat: 참고 자료 URL의 Open Graph 메타데이터 조회 API 추가

### DIFF
--- a/codes/server/Cargo.lock
+++ b/codes/server/Cargo.lock
@@ -3532,6 +3532,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",

--- a/codes/server/Cargo.lock
+++ b/codes/server/Cargo.lock
@@ -632,6 +632,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa 1.0.17",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +854,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa 1.0.11",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +912,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -1125,6 +1169,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1314,15 @@ dependencies = [
  "lopdf",
  "printpdf",
  "rusttype",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1388,6 +1460,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "match_token",
 ]
 
 [[package]]
@@ -1851,7 +1935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49a0272112719d0037ab63d4bb67f73ba659e1e90bc38f235f163a457ac16f3"
 dependencies = [
  "chrono",
- "dtoa",
+ "dtoa 0.4.8",
  "encoding",
  "flate2",
  "itoa 0.4.8",
@@ -1873,6 +1957,37 @@ name = "lzw"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "matchers"
@@ -1981,6 +2096,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -2271,6 +2392,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2514,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "primeorder"
@@ -3043,6 +3222,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "sea-bae"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3392,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more 0.99.20",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,6 +3517,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.13.1",
+ "scraper",
  "sea-orm",
  "serde",
  "serde_json",
@@ -3322,6 +3536,15 @@ dependencies = [
  "utoipa-swagger-ui",
  "uuid",
  "validator",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3419,6 +3642,12 @@ dependencies = [
  "thiserror 2.0.17",
  "time 0.3.45",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -3752,6 +3981,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,6 +4114,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -4316,6 +4581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4338,6 +4609,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/codes/server/Cargo.toml
+++ b/codes/server/Cargo.toml
@@ -66,6 +66,7 @@ sea-orm = { version = "1.1.19", features = ["sqlx-mysql", "runtime-tokio-native-
 genpdf = "0.2"
 jsonwebtoken = { version = "10.2.0", features = ["rust_crypto"] }
 reqwest = { version = "0.13.1", features = ["json", "form"] }
+scraper = "0.22"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/codes/server/Cargo.toml
+++ b/codes/server/Cargo.toml
@@ -67,6 +67,7 @@ genpdf = "0.2"
 jsonwebtoken = { version = "10.2.0", features = ["rust_crypto"] }
 reqwest = { version = "0.13.1", features = ["json", "form"] }
 scraper = "0.22"
+url = "2"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/codes/server/src/domain/mod.rs
+++ b/codes/server/src/domain/mod.rs
@@ -2,5 +2,6 @@
 pub mod ai;
 pub mod auth;
 pub mod member;
+pub mod og;
 pub mod retrospect;
 pub mod webhook;

--- a/codes/server/src/domain/og/dto.rs
+++ b/codes/server/src/domain/og/dto.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::Validate;
+
+/// OG 메타데이터 조회 쿼리 파라미터
+#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OgMetadataQuery {
+    #[validate(length(
+        min = 1,
+        max = 2048,
+        message = "URL은 1자 이상 2,048자 이하여야 합니다"
+    ))]
+    pub url: String,
+}
+
+/// OG 메타데이터 응답
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OgMetadataResponse {
+    /// 요청한 원본 URL
+    pub url: String,
+    /// og:title 값
+    pub title: Option<String>,
+    /// og:description 값
+    pub description: Option<String>,
+    /// og:image 값
+    pub image: Option<String>,
+}
+
+/// Swagger용 성공 응답
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuccessOgMetadataResponse {
+    pub is_success: bool,
+    pub code: String,
+    pub message: String,
+    pub result: OgMetadataResponse,
+}

--- a/codes/server/src/domain/og/handler.rs
+++ b/codes/server/src/domain/og/handler.rs
@@ -1,0 +1,37 @@
+use axum::extract::{Query, State};
+use axum::Json;
+use validator::Validate;
+
+use crate::domain::og::dto::{OgMetadataQuery, OgMetadataResponse};
+use crate::domain::og::service::OgService;
+use crate::state::AppState;
+use crate::utils::auth::AuthUser;
+use crate::utils::error::AppError;
+use crate::utils::response::BaseResponse;
+
+/// Open Graph 메타데이터 조회
+#[utoipa::path(
+    get,
+    path = "/api/v1/og",
+    params(
+        ("url" = String, Query, description = "OG 태그를 파싱할 대상 URL")
+    ),
+    responses(
+        (status = 200, description = "OG 메타데이터 조회 성공", body = SuccessOgMetadataResponse),
+        (status = 400, description = "잘못된 요청", body = ErrorResponse),
+        (status = 401, description = "인증 실패", body = ErrorResponse)
+    ),
+    security(
+        ("bearer_auth" = [])
+    ),
+    tag = "OG"
+)]
+pub async fn get_og_metadata(
+    State(_state): State<AppState>,
+    _user: AuthUser,
+    Query(query): Query<OgMetadataQuery>,
+) -> Result<Json<BaseResponse<OgMetadataResponse>>, AppError> {
+    query.validate()?;
+    let result = OgService::fetch_metadata(&query.url).await?;
+    Ok(Json(BaseResponse::success(result)))
+}

--- a/codes/server/src/domain/og/handler.rs
+++ b/codes/server/src/domain/og/handler.rs
@@ -1,10 +1,9 @@
-use axum::extract::{Query, State};
+use axum::extract::Query;
 use axum::Json;
 use validator::Validate;
 
 use crate::domain::og::dto::{OgMetadataQuery, OgMetadataResponse};
 use crate::domain::og::service::OgService;
-use crate::state::AppState;
 use crate::utils::auth::AuthUser;
 use crate::utils::error::AppError;
 use crate::utils::response::BaseResponse;
@@ -27,7 +26,6 @@ use crate::utils::response::BaseResponse;
     tag = "OG"
 )]
 pub async fn get_og_metadata(
-    State(_state): State<AppState>,
     _user: AuthUser,
     Query(query): Query<OgMetadataQuery>,
 ) -> Result<Json<BaseResponse<OgMetadataResponse>>, AppError> {

--- a/codes/server/src/domain/og/mod.rs
+++ b/codes/server/src/domain/og/mod.rs
@@ -1,0 +1,3 @@
+pub mod dto;
+pub mod handler;
+pub mod service;

--- a/codes/server/src/domain/og/service.rs
+++ b/codes/server/src/domain/og/service.rs
@@ -1,0 +1,276 @@
+use crate::domain::og::dto::OgMetadataResponse;
+use crate::utils::error::AppError;
+use scraper::{Html, Selector};
+use tracing::{info, warn};
+
+const REQUEST_TIMEOUT_SECS: u64 = 5;
+const USER_AGENT: &str = "Mozilla/5.0 (compatible; MoalogBot/1.0)";
+
+pub struct OgService;
+
+impl OgService {
+    /// 외부 URL에서 Open Graph 메타데이터를 파싱하여 반환합니다.
+    /// 파싱 실패 시에도 에러가 아닌 URL만 포함한 fallback 응답을 반환합니다.
+    pub async fn fetch_metadata(url: &str) -> Result<OgMetadataResponse, AppError> {
+        if !is_valid_url(url) {
+            return Err(AppError::BadRequest(
+                "유효하지 않은 URL 형식입니다.".to_string(),
+            ));
+        }
+
+        info!(url = %url, "OG 메타데이터 파싱 시작");
+
+        let html = match fetch_html(url).await {
+            Ok(html) => html,
+            Err(e) => {
+                warn!(url = %url, error = %e, "외부 URL 요청 실패, fallback 응답 반환");
+                return Ok(fallback_response(url));
+            }
+        };
+
+        let metadata = parse_og_tags(&html);
+
+        Ok(OgMetadataResponse {
+            url: url.to_string(),
+            title: metadata.title,
+            description: metadata.description,
+            image: metadata.image,
+        })
+    }
+}
+
+/// URL 형식이 유효한지 검증합니다.
+fn is_valid_url(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://")
+}
+
+/// 외부 URL에서 HTML을 가져옵니다.
+async fn fetch_html(url: &str) -> Result<String, AppError> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| AppError::InternalError(format!("HTTP 클라이언트 생성 실패: {}", e)))?;
+
+    let response = client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| AppError::InternalError(format!("외부 URL 요청 실패: {}", e)))?;
+
+    let text = response
+        .text()
+        .await
+        .map_err(|e| AppError::InternalError(format!("응답 본문 읽기 실패: {}", e)))?;
+
+    Ok(text)
+}
+
+struct OgTags {
+    title: Option<String>,
+    description: Option<String>,
+    image: Option<String>,
+}
+
+/// HTML에서 Open Graph 태그를 파싱합니다.
+fn parse_og_tags(html: &str) -> OgTags {
+    let document = Html::parse_document(html);
+
+    let title = extract_og_content(&document, "og:title");
+    let description = extract_og_content(&document, "og:description");
+    let image = extract_og_content(&document, "og:image");
+
+    OgTags {
+        title,
+        description,
+        image,
+    }
+}
+
+/// 특정 OG 속성의 content 값을 추출합니다.
+fn extract_og_content(document: &Html, property: &str) -> Option<String> {
+    let selector = Selector::parse(&format!("meta[property=\"{}\"]", property)).ok()?;
+
+    document
+        .select(&selector)
+        .next()
+        .and_then(|el| el.value().attr("content"))
+        .map(|s| s.to_string())
+}
+
+/// 파싱 실패 시 URL만 포함한 fallback 응답을 반환합니다.
+fn fallback_response(url: &str) -> OgMetadataResponse {
+    OgMetadataResponse {
+        url: url.to_string(),
+        title: None,
+        description: None,
+        image: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_return_true_for_valid_http_url() {
+        // Arrange
+        let url = "http://example.com";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(result);
+    }
+
+    #[test]
+    fn should_return_true_for_valid_https_url() {
+        // Arrange
+        let url = "https://example.com";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(result);
+    }
+
+    #[test]
+    fn should_return_false_for_invalid_url() {
+        // Arrange
+        let url = "not-a-url";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_ftp_url() {
+        // Arrange
+        let url = "ftp://example.com";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_parse_og_tags_from_html() {
+        // Arrange
+        let html = r#"
+            <html>
+            <head>
+                <meta property="og:title" content="Test Title" />
+                <meta property="og:description" content="Test Description" />
+                <meta property="og:image" content="https://example.com/image.png" />
+            </head>
+            <body></body>
+            </html>
+        "#;
+
+        // Act
+        let result = parse_og_tags(html);
+
+        // Assert
+        assert_eq!(result.title, Some("Test Title".to_string()));
+        assert_eq!(result.description, Some("Test Description".to_string()));
+        assert_eq!(
+            result.image,
+            Some("https://example.com/image.png".to_string())
+        );
+    }
+
+    #[test]
+    fn should_return_none_for_missing_og_tags() {
+        // Arrange
+        let html = r#"
+            <html>
+            <head><title>No OG Tags</title></head>
+            <body></body>
+            </html>
+        "#;
+
+        // Act
+        let result = parse_og_tags(html);
+
+        // Assert
+        assert!(result.title.is_none());
+        assert!(result.description.is_none());
+        assert!(result.image.is_none());
+    }
+
+    #[test]
+    fn should_parse_partial_og_tags() {
+        // Arrange
+        let html = r#"
+            <html>
+            <head>
+                <meta property="og:title" content="Only Title" />
+            </head>
+            <body></body>
+            </html>
+        "#;
+
+        // Act
+        let result = parse_og_tags(html);
+
+        // Assert
+        assert_eq!(result.title, Some("Only Title".to_string()));
+        assert!(result.description.is_none());
+        assert!(result.image.is_none());
+    }
+
+    #[test]
+    fn should_handle_empty_content_attribute() {
+        // Arrange
+        let html = r#"
+            <html>
+            <head>
+                <meta property="og:title" content="" />
+            </head>
+            <body></body>
+            </html>
+        "#;
+
+        // Act
+        let result = parse_og_tags(html);
+
+        // Assert
+        assert_eq!(result.title, Some("".to_string()));
+    }
+
+    #[test]
+    fn should_return_fallback_response_with_url_only() {
+        // Arrange
+        let url = "https://example.com";
+
+        // Act
+        let result = fallback_response(url);
+
+        // Assert
+        assert_eq!(result.url, "https://example.com");
+        assert!(result.title.is_none());
+        assert!(result.description.is_none());
+        assert!(result.image.is_none());
+    }
+
+    #[tokio::test]
+    async fn should_return_error_for_invalid_url_format() {
+        // Arrange
+        let url = "not-a-valid-url";
+
+        // Act
+        let result = OgService::fetch_metadata(url).await;
+
+        // Assert
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.error_code(), "COMMON400");
+    }
+}

--- a/codes/server/src/domain/og/service.rs
+++ b/codes/server/src/domain/og/service.rs
@@ -1,10 +1,21 @@
 use crate::domain::og::dto::OgMetadataResponse;
 use crate::utils::error::AppError;
+use reqwest::Client;
 use scraper::{Html, Selector};
+use std::sync::LazyLock;
 use tracing::{info, warn};
+use url::{Host, Url};
 
 const REQUEST_TIMEOUT_SECS: u64 = 5;
 const USER_AGENT: &str = "Mozilla/5.0 (compatible; MoalogBot/1.0)";
+
+/// 공유 HTTP 클라이언트 (커넥션 풀링 활용)
+static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .build()
+        .expect("HTTP 클라이언트 초기화 실패")
+});
 
 pub struct OgService;
 
@@ -40,23 +51,47 @@ impl OgService {
 }
 
 /// URL 형식이 유효한지 검증합니다.
+/// SSRF 방지를 위해 내부 네트워크 주소를 차단합니다.
+/// NOTE: DNS rebinding 공격에 대한 완전한 방어를 위해서는 DNS 해석 후 IP 재검증이 필요합니다.
 fn is_valid_url(url: &str) -> bool {
-    url.starts_with("http://") || url.starts_with("https://")
+    let parsed = match Url::parse(url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return false;
+    }
+
+    match parsed.host() {
+        Some(Host::Domain(domain)) => {
+            let domain = domain.to_ascii_lowercase();
+            domain != "localhost"
+        }
+        Some(Host::Ipv4(ipv4)) => {
+            !(ipv4.is_loopback()          // 127.0.0.0/8
+                || ipv4.is_private()      // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+                || ipv4.is_link_local()   // 169.254.0.0/16
+                || ipv4.is_unspecified()) // 0.0.0.0
+        }
+        Some(Host::Ipv6(ipv6)) => {
+            !(ipv6.is_loopback()          // ::1
+                || ipv6.is_unspecified()) // ::
+        }
+        None => false,
+    }
 }
 
 /// 외부 URL에서 HTML을 가져옵니다.
 async fn fetch_html(url: &str) -> Result<String, AppError> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
-        .build()
-        .map_err(|e| AppError::InternalError(format!("HTTP 클라이언트 생성 실패: {}", e)))?;
-
-    let response = client
+    let response = HTTP_CLIENT
         .get(url)
         .header(reqwest::header::USER_AGENT, USER_AGENT)
         .send()
         .await
-        .map_err(|e| AppError::InternalError(format!("외부 URL 요청 실패: {}", e)))?;
+        .map_err(|e| AppError::InternalError(format!("외부 URL 요청 실패: {}", e)))?
+        .error_for_status()
+        .map_err(|e| AppError::InternalError(format!("외부 URL 응답 오류: {}", e)))?;
 
     let text = response
         .text()
@@ -152,6 +187,90 @@ mod tests {
     fn should_return_false_for_ftp_url() {
         // Arrange
         let url = "ftp://example.com";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_localhost() {
+        // Arrange
+        let url = "http://localhost:8080/admin";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_loopback_ip() {
+        // Arrange
+        let url = "http://127.0.0.1/admin";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_aws_metadata_endpoint() {
+        // Arrange
+        let url = "http://169.254.169.254/latest/meta-data/";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_private_network_10() {
+        // Arrange
+        let url = "http://10.0.0.1/internal";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_private_network_172() {
+        // Arrange
+        let url = "http://172.16.0.1/internal";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_private_network_192() {
+        // Arrange
+        let url = "http://192.168.1.1/internal";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_ipv6_loopback() {
+        // Arrange
+        let url = "http://[::1]/admin";
 
         // Act
         let result = is_valid_url(url);
@@ -264,6 +383,34 @@ mod tests {
     async fn should_return_error_for_invalid_url_format() {
         // Arrange
         let url = "not-a-valid-url";
+
+        // Act
+        let result = OgService::fetch_metadata(url).await;
+
+        // Assert
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.error_code(), "COMMON400");
+    }
+
+    #[tokio::test]
+    async fn should_return_error_for_localhost_ssrf() {
+        // Arrange
+        let url = "http://localhost:8080/internal";
+
+        // Act
+        let result = OgService::fetch_metadata(url).await;
+
+        // Assert
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.error_code(), "COMMON400");
+    }
+
+    #[tokio::test]
+    async fn should_return_error_for_private_ip_ssrf() {
+        // Arrange
+        let url = "http://169.254.169.254/latest/meta-data/";
 
         // Act
         let result = OgService::fetch_metadata(url).await;

--- a/codes/server/src/domain/og/service.rs
+++ b/codes/server/src/domain/og/service.rs
@@ -1,18 +1,23 @@
 use crate::domain::og::dto::OgMetadataResponse;
 use crate::utils::error::AppError;
+use reqwest::redirect::Policy;
 use reqwest::Client;
 use scraper::{Html, Selector};
+use std::net::Ipv6Addr;
 use std::sync::LazyLock;
 use tracing::{info, warn};
 use url::{Host, Url};
 
 const REQUEST_TIMEOUT_SECS: u64 = 5;
 const USER_AGENT: &str = "Mozilla/5.0 (compatible; MoalogBot/1.0)";
+/// 응답 본문 최대 크기 (1MB)
+const MAX_BODY_BYTES: usize = 1_024 * 1_024;
 
-/// 공유 HTTP 클라이언트 (커넥션 풀링 활용)
+/// 공유 HTTP 클라이언트 (커넥션 풀링 활용, 리다이렉트 비활성화)
 static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
     Client::builder()
         .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .redirect(Policy::none())
         .build()
         .expect("HTTP 클라이언트 초기화 실패")
 });
@@ -74,15 +79,43 @@ fn is_valid_url(url: &str) -> bool {
                 || ipv4.is_link_local()   // 169.254.0.0/16
                 || ipv4.is_unspecified()) // 0.0.0.0
         }
-        Some(Host::Ipv6(ipv6)) => {
-            !(ipv6.is_loopback()          // ::1
-                || ipv6.is_unspecified()) // ::
-        }
+        Some(Host::Ipv6(ipv6)) => !is_blocked_ipv6(&ipv6),
         None => false,
     }
 }
 
+/// IPv6 주소가 차단 대상인지 확인합니다.
+/// IPv4-mapped IPv6 주소(::ffff:x.x.x.x), 유니크 로컬(fc00::/7), 링크로컬(fe80::/10)도 차단합니다.
+fn is_blocked_ipv6(ipv6: &Ipv6Addr) -> bool {
+    if ipv6.is_loopback() || ipv6.is_unspecified() {
+        return true;
+    }
+
+    // IPv4-mapped IPv6 (::ffff:x.x.x.x) → 내부 IPv4로 매핑된 주소 차단
+    if let Some(ipv4) = ipv6.to_ipv4_mapped() {
+        return ipv4.is_loopback()
+            || ipv4.is_private()
+            || ipv4.is_link_local()
+            || ipv4.is_unspecified();
+    }
+
+    let segments = ipv6.segments();
+
+    // 유니크 로컬 주소 fc00::/7 (첫 7비트가 1111110)
+    if segments[0] & 0xfe00 == 0xfc00 {
+        return true;
+    }
+
+    // 링크로컬 주소 fe80::/10 (첫 10비트가 1111111010)
+    if segments[0] & 0xffc0 == 0xfe80 {
+        return true;
+    }
+
+    false
+}
+
 /// 외부 URL에서 HTML을 가져옵니다.
+/// 리다이렉트는 SSRF 방지를 위해 비활성화되어 있으며, 3xx 응답은 fallback 처리됩니다.
 async fn fetch_html(url: &str) -> Result<String, AppError> {
     let response = HTTP_CLIENT
         .get(url)
@@ -93,12 +126,27 @@ async fn fetch_html(url: &str) -> Result<String, AppError> {
         .error_for_status()
         .map_err(|e| AppError::InternalError(format!("외부 URL 응답 오류: {}", e)))?;
 
-    let text = response
-        .text()
+    let content_length = response.content_length().unwrap_or(0) as usize;
+
+    if content_length > MAX_BODY_BYTES {
+        return Err(AppError::InternalError(
+            "응답 본문이 너무 큽니다.".to_string(),
+        ));
+    }
+
+    let bytes = response
+        .bytes()
         .await
         .map_err(|e| AppError::InternalError(format!("응답 본문 읽기 실패: {}", e)))?;
 
-    Ok(text)
+    if bytes.len() > MAX_BODY_BYTES {
+        return Err(AppError::InternalError(
+            "응답 본문이 너무 큽니다.".to_string(),
+        ));
+    }
+
+    String::from_utf8(bytes.to_vec())
+        .map_err(|e| AppError::InternalError(format!("응답 인코딩 오류: {}", e)))
 }
 
 struct OgTags {
@@ -280,6 +328,54 @@ mod tests {
     }
 
     #[test]
+    fn should_return_false_for_ipv4_mapped_ipv6_loopback() {
+        // Arrange
+        let url = "http://[::ffff:127.0.0.1]/admin";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_ipv4_mapped_ipv6_private() {
+        // Arrange
+        let url = "http://[::ffff:10.0.0.1]/internal";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_ipv6_unique_local() {
+        // Arrange
+        let url = "http://[fc00::1]/internal";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
+    fn should_return_false_for_ipv6_link_local() {
+        // Arrange
+        let url = "http://[fe80::1]/internal";
+
+        // Act
+        let result = is_valid_url(url);
+
+        // Assert
+        assert!(!result);
+    }
+
+    #[test]
     fn should_parse_og_tags_from_html() {
         // Arrange
         let html = r#"
@@ -411,6 +507,20 @@ mod tests {
     async fn should_return_error_for_private_ip_ssrf() {
         // Arrange
         let url = "http://169.254.169.254/latest/meta-data/";
+
+        // Act
+        let result = OgService::fetch_metadata(url).await;
+
+        // Assert
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.error_code(), "COMMON400");
+    }
+
+    #[tokio::test]
+    async fn should_return_error_for_ipv4_mapped_ipv6_ssrf() {
+        // Arrange
+        let url = "http://[::ffff:127.0.0.1]/admin";
 
         // Act
         let result = OgService::fetch_metadata(url).await;

--- a/codes/server/src/main.rs
+++ b/codes/server/src/main.rs
@@ -29,6 +29,7 @@ use crate::domain::member::dto::{
     MemberProfileResponse, SuccessProfileResponse, SuccessWithdrawResponse,
 };
 use crate::domain::member::entity::member_retro::RetrospectStatus;
+use crate::domain::og::dto::{OgMetadataQuery, OgMetadataResponse, SuccessOgMetadataResponse};
 use crate::domain::retrospect::dto::{
     AnalysisResponse, AssistantRequest, AssistantResponse, CommentItem, CreateCommentRequest,
     CreateCommentResponse, CreateParticipantResponse, CreateRetrospectRequest,
@@ -97,7 +98,9 @@ use crate::utils::{BaseResponse, ErrorResponse};
         domain::retrospect::handler::assistant_guide,
         // Member APIs
         domain::member::handler::get_profile,
-        domain::member::handler::withdraw
+        domain::member::handler::withdraw,
+        // OG APIs
+        domain::og::handler::get_og_metadata
     ),
     components(
         schemas(
@@ -198,7 +201,11 @@ use crate::utils::{BaseResponse, ErrorResponse};
             // Member DTOs
             MemberProfileResponse,
             SuccessProfileResponse,
-            SuccessWithdrawResponse
+            SuccessWithdrawResponse,
+            // OG DTOs
+            OgMetadataQuery,
+            OgMetadataResponse,
+            SuccessOgMetadataResponse
         )
     ),
     tags(
@@ -207,7 +214,8 @@ use crate::utils::{BaseResponse, ErrorResponse};
         (name = "RetroRoom", description = "회고방 관리 API"),
         (name = "Retrospect", description = "회고 API"),
         (name = "Response", description = "회고 답변 API"),
-        (name = "Member", description = "회원 API")
+        (name = "Member", description = "회원 API"),
+        (name = "OG", description = "Open Graph 메타데이터 API")
     ),
     modifiers(&SecurityAddon),
     info(
@@ -435,6 +443,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route(
             "/api/v1/retrospects/:retrospect_id/questions/:question_id/assistant",
             axum::routing::post(domain::retrospect::handler::assistant_guide),
+        )
+        // [API-128] OG 메타데이터 조회
+        .route(
+            "/api/v1/og",
+            axum::routing::get(domain::og::handler::get_og_metadata),
         )
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
         // 레이어 순서: 아래에서 위로 적용됨 (request_id → cors → TraceLayer → handler)

--- a/docs/api-specs/128-og-metadata.md
+++ b/docs/api-specs/128-og-metadata.md
@@ -1,0 +1,90 @@
+# API-128: Open Graph 메타데이터 조회
+
+## 개요
+
+외부 URL의 Open Graph 태그를 파싱하여 메타데이터(제목, 설명, 썸네일 등)를 반환합니다.
+클라이언트에서 CORS로 인해 직접 외부 URL을 요청할 수 없으므로, 백엔드에서 프록시 역할을 합니다.
+
+## 엔드포인트
+
+```
+GET /api/v1/og?url={url}
+```
+
+## 인증
+
+Bearer Token 필수
+
+## 요청
+
+### Query Parameters
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|----------|------|------|------|
+| `url` | string | O | OG 태그를 파싱할 대상 URL (최대 2,048자) |
+
+### 예시
+
+```
+GET /api/v1/og?url=https://github.com/example/project
+```
+
+## 응답
+
+### 성공 (200 OK)
+
+#### OG 태그 파싱 성공
+
+```json
+{
+  "isSuccess": true,
+  "code": "COMMON200",
+  "message": "성공입니다.",
+  "result": {
+    "url": "https://github.com/example/project",
+    "title": "example/project",
+    "description": "An example project repository",
+    "image": "https://opengraph.githubassets.com/example.png"
+  }
+}
+```
+
+#### OG 태그 파싱 실패 (graceful fallback)
+
+외부 사이트 접근 불가, OG 태그 미존재 등의 경우 URL만 반환합니다.
+
+```json
+{
+  "isSuccess": true,
+  "code": "COMMON200",
+  "message": "성공입니다.",
+  "result": {
+    "url": "https://example.com/no-og",
+    "title": null,
+    "description": null,
+    "image": null
+  }
+}
+```
+
+### 에러 응답
+
+| 코드 | HTTP | 설명 |
+|------|------|------|
+| `COMMON400` | 400 | URL 파라미터 누락 또는 잘못된 URL 형식 |
+| `AUTH4001` | 401 | 인증 실패 |
+
+## 응답 필드
+
+| 필드 | 타입 | Nullable | 설명 |
+|------|------|----------|------|
+| `url` | string | N | 요청한 원본 URL |
+| `title` | string | Y | `og:title` 값 |
+| `description` | string | Y | `og:description` 값 |
+| `image` | string | Y | `og:image` 값 |
+
+## 참고 사항
+
+- 외부 URL 요청 타임아웃: 5초
+- User-Agent 헤더를 설정하여 봇 차단 우회
+- 파싱 실패 시에도 200 OK로 URL만 반환 (graceful fallback)

--- a/docs/reviews/128-og-metadata.md
+++ b/docs/reviews/128-og-metadata.md
@@ -1,0 +1,62 @@
+# API-128: Open Graph 메타데이터 조회 API 리뷰
+
+## 개요
+
+외부 URL의 Open Graph 태그를 파싱하여 메타데이터(제목, 설명, 썸네일 이미지)를 반환하는 API입니다.
+클라이언트에서 CORS로 직접 외부 URL에 접근할 수 없으므로 백엔드에서 프록시 역할을 합니다.
+
+## 엔드포인트
+
+```
+GET /api/v1/og?url={url}
+```
+
+## 구현 내용
+
+### 새 도메인 모듈: `og`
+
+| 파일 | 역할 |
+|------|------|
+| `src/domain/og/mod.rs` | 모듈 정의 |
+| `src/domain/og/dto.rs` | OgMetadataQuery, OgMetadataResponse |
+| `src/domain/og/service.rs` | URL 요청 및 OG 태그 파싱 로직 |
+| `src/domain/og/handler.rs` | HTTP 핸들러 |
+
+### 주요 설계 결정
+
+1. **Graceful Fallback**: 외부 URL 요청 실패 시에도 200 OK로 URL만 반환 (에러 X)
+2. **타임아웃 5초**: 외부 사이트 응답 지연에 대비
+3. **User-Agent 설정**: 봇 차단 우회를 위해 브라우저 유사 User-Agent 사용
+4. **인증 필수**: Bearer Token으로 남용 방지
+
+### 의존성 추가
+
+- `scraper = "0.22"` : HTML 파싱 및 CSS 셀렉터 기반 OG 태그 추출
+
+## 테스트
+
+### 단위 테스트 (8개)
+
+| 테스트 | 검증 내용 |
+|--------|----------|
+| `should_return_true_for_valid_http_url` | http:// URL 검증 |
+| `should_return_true_for_valid_https_url` | https:// URL 검증 |
+| `should_return_false_for_invalid_url` | 잘못된 URL 형식 거부 |
+| `should_return_false_for_ftp_url` | ftp:// URL 거부 |
+| `should_parse_og_tags_from_html` | OG 태그 전체 파싱 |
+| `should_return_none_for_missing_og_tags` | OG 태그 없는 HTML 처리 |
+| `should_parse_partial_og_tags` | 일부 OG 태그만 있는 경우 |
+| `should_handle_empty_content_attribute` | 빈 content 속성 처리 |
+| `should_return_fallback_response_with_url_only` | fallback 응답 검증 |
+| `should_return_error_for_invalid_url_format` | 잘못된 URL에 대한 에러 |
+
+## 코드 리뷰 체크리스트
+
+- [x] TDD 원칙을 따라 테스트 코드가 작성되었는가?
+- [x] 모든 테스트가 통과하는가?
+- [x] API 문서가 작성되었는가?
+- [x] 공통 유틸리티(BaseResponse, AppError)를 재사용했는가?
+- [x] 에러 처리가 적절하게 되어 있는가? (unwrap 미사용)
+- [x] 코드가 Rust 컨벤션을 따르는가? (clippy 경고 없음)
+- [x] serde rename_all = "camelCase" 적용되었는가?
+- [x] Swagger 문서가 작성되었는가?


### PR DESCRIPTION
## Summary
- 외부 URL의 Open Graph 태그를 파싱하여 메타데이터(제목, 설명, 썸네일)를 반환하는 `GET /api/v1/og?url={url}` API 추가
- 클라이언트 CORS 문제 해결을 위해 백엔드에서 프록시 역할 수행
- 파싱 실패 시에도 200 OK로 URL만 반환하는 graceful fallback 적용

## Changes
- `src/domain/og/` 모듈 신규 생성 (handler, service, dto)
- `scraper` 의존성 추가 (HTML 파싱)
- Swagger 문서 및 API 스펙/리뷰 문서 작성

## Test plan
- [x] OG 태그 파싱 단위 테스트 통과 (8개)
- [x] `cargo clippy -- -D warnings` 경고 없음
- [x] `cargo fmt` 적용 완료

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint (GET /api/v1/og) to retrieve Open Graph metadata (url, title, description, image); authentication required.
  * Added request/response schemas for OG metadata and integrated them into API documentation.

* **Behavior**
  * Robust validation, SSRF-aware URL checks, and fallback behavior when external metadata is unavailable.

* **Tests**
  * Unit tests covering validation, parsing, fallback, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->