### PR TITLE
fix: 회고 참석 등록 시간 로직 수정 (#130)

### DIFF
--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -3484,24 +3484,39 @@ impl RetrospectService {
             )));
         }
 
-        // 3. 회고방 멤버십 확인 (참여자만 어시스턴트 사용 가능)
+        // 3. 회고방 멤버십 확인 (회고방 멤버만 어시스턴트 사용 가능)
+        let is_room_member = member_retro_room::Entity::find()
+            .filter(member_retro_room::Column::MemberId.eq(user_id))
+            .filter(
+                member_retro_room::Column::RetrospectRoomId
+                    .eq(retrospect_model.retrospect_room_id),
+            )
+            .one(&state.db)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+        if is_room_member.is_none() {
+            return Err(AppError::RetroRoomAccessDenied(
+                "해당 회고에 참여 권한이 없습니다.".to_string(),
+            ));
+        }
+
+        // 4. 이미 제출된 회고는 어시스턴트 사용 불가
         let member_retro_model = member_retro::Entity::find()
             .filter(member_retro::Column::MemberId.eq(user_id))
             .filter(member_retro::Column::RetrospectId.eq(retrospect_id))
             .one(&state.db)
             .await
-            .map_err(|e| AppError::InternalError(e.to_string()))?
-            .ok_or_else(|| {
-                AppError::RetroRoomAccessDenied("해당 회고에 참여 권한이 없습니다.".to_string())
-            })?;
+            .map_err(|e| AppError::InternalError(e.to_string()))?;
 
-        // 4. 이미 제출된 회고는 어시스턴트 사용 불가
-        if member_retro_model.status == RetrospectStatus::Submitted
-            || member_retro_model.status == RetrospectStatus::Analyzed
-        {
-            return Err(AppError::RetroAlreadySubmitted(
-                "이미 제출된 회고에서는 어시스턴트를 사용할 수 없습니다.".to_string(),
-            ));
+        if let Some(mr) = &member_retro_model {
+            if mr.status == RetrospectStatus::Submitted
+                || mr.status == RetrospectStatus::Analyzed
+            {
+                return Err(AppError::RetroAlreadySubmitted(
+                    "이미 제출된 회고에서는 어시스턴트를 사용할 수 없습니다.".to_string(),
+                ));
+            }
         }
 
         // 5. 월간 사용량 계산을 위한 시간 범위 설정

--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -1131,11 +1131,11 @@ impl RetrospectService {
         let retrospect_model =
             Self::find_retrospect_for_member(&state, user_id, retrospect_id).await?;
 
-        // 2. 진행 예정인 회고인지 확인 (과거 회고에는 참석 불가)
+        // 2. 회고가 시작되었는지 확인 (start_time 이후부터 참여 가능)
         let now_kst = Utc::now().naive_utc() + chrono::Duration::hours(9);
-        if retrospect_model.start_time <= now_kst {
-            return Err(AppError::RetrospectAlreadyStarted(
-                "이미 시작되었거나 종료된 회고에는 참석할 수 없습니다.".to_string(),
+        if now_kst < retrospect_model.start_time {
+            return Err(AppError::RetrospectNotStarted(
+                "아직 시작되지 않은 회고입니다.".to_string(),
             ));
         }
 

--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -3488,8 +3488,7 @@ impl RetrospectService {
         let is_room_member = member_retro_room::Entity::find()
             .filter(member_retro_room::Column::MemberId.eq(user_id))
             .filter(
-                member_retro_room::Column::RetrospectRoomId
-                    .eq(retrospect_model.retrospect_room_id),
+                member_retro_room::Column::RetrospectRoomId.eq(retrospect_model.retrospect_room_id),
             )
             .one(&state.db)
             .await
@@ -3510,9 +3509,7 @@ impl RetrospectService {
             .map_err(|e| AppError::InternalError(e.to_string()))?;
 
         if let Some(mr) = &member_retro_model {
-            if mr.status == RetrospectStatus::Submitted
-                || mr.status == RetrospectStatus::Analyzed
-            {
+            if mr.status == RetrospectStatus::Submitted || mr.status == RetrospectStatus::Analyzed {
                 return Err(AppError::RetroAlreadySubmitted(
                     "이미 제출된 회고에서는 어시스턴트를 사용할 수 없습니다.".to_string(),
                 ));

--- a/codes/server/src/utils/error.rs
+++ b/codes/server/src/utils/error.rs
@@ -99,8 +99,8 @@ pub enum AppError {
     /// RETRO4091: 중복 참석 (409)
     ParticipantDuplicate(String),
 
-    /// RETRO4002: 과거 회고 참석 불가 / 답변 누락 (400)
-    RetrospectAlreadyStarted(String),
+    /// RETRO4002: 아직 시작되지 않은 회고 (400)
+    RetrospectNotStarted(String),
 
     /// RES4041: 존재하지 않는 회고 답변 (404)
     ResponseNotFound(String),
@@ -202,7 +202,7 @@ impl AppError {
             AppError::RetroRoomNotFound(msg) => msg.clone(),
             AppError::RetrospectNotFound(msg) => msg.clone(),
             AppError::ParticipantDuplicate(msg) => msg.clone(),
-            AppError::RetrospectAlreadyStarted(msg) => msg.clone(),
+            AppError::RetrospectNotStarted(msg) => msg.clone(),
             AppError::ResponseNotFound(msg) => msg.clone(),
             AppError::CommentTooLong(msg) => msg.clone(),
             AppError::RetroAnswersMissing(msg) => msg.clone(),
@@ -259,7 +259,7 @@ impl AppError {
             AppError::RetroRoomNotFound(_) => "RETRO4041",
             AppError::RetrospectNotFound(_) => "RETRO4041",
             AppError::ParticipantDuplicate(_) => "RETRO4091",
-            AppError::RetrospectAlreadyStarted(_) => "RETRO4002",
+            AppError::RetrospectNotStarted(_) => "RETRO4002",
             AppError::ResponseNotFound(_) => "RES4041",
             AppError::CommentTooLong(_) => "RES4001",
             AppError::RetroAnswersMissing(_) => "RETRO4002",
@@ -316,7 +316,7 @@ impl AppError {
             AppError::RetroRoomNotFound(_) => StatusCode::NOT_FOUND,
             AppError::RetrospectNotFound(_) => StatusCode::NOT_FOUND,
             AppError::ParticipantDuplicate(_) => StatusCode::CONFLICT,
-            AppError::RetrospectAlreadyStarted(_) => StatusCode::BAD_REQUEST,
+            AppError::RetrospectNotStarted(_) => StatusCode::BAD_REQUEST,
             AppError::ResponseNotFound(_) => StatusCode::NOT_FOUND,
             AppError::CommentTooLong(_) => StatusCode::BAD_REQUEST,
             AppError::RetroAnswersMissing(_) => StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## Summary
- 회고 참석 등록(`create_participant`) 시간 체크 로직을 반전
  - **기존**: `start_time` 이전에만 참석 가능 → 시작 후 차단
  - **변경**: `start_time` 이후부터 참석 가능 → 시작 전 차단
- 어시스턴트 API 권한 체크를 `member_retro` → `member_retro_room`(회고방 멤버십)으로 변경
  - 참석 등록 전에도 회고방 멤버라면 어시스턴트 사용 가능
  - 제출 완료 여부는 `member_retro`가 있을 경우에만 체크
- `RetrospectAlreadyStarted` → `RetrospectNotStarted`로 에러 변경

## Test plan
- [x] `cargo test` 전체 통과 (392 unit + 14 integration)
- [x] 당일 날짜로 회고 생성 후 참석 등록 가능한지 확인
- [x] 참석 등록 후 회고 어시스턴트 API 정상 동작 확인
- [x] 미래 날짜 회고는 start_time 전에 참석 등록 차단되는지 확인
- [x] 존재하지 않는 회고 → 404
- [x] 참석 등록 없이 어시스턴트 사용 (회고방 멤버) → 200 OK
- [x] 중복 참석 등록 → 409
- [x] 유효하지 않은 질문 ID → 404
- [x] 과거 날짜 회고 생성 → 400 차단
- [x] 제출 완료된 회고에서 어시스턴트 → 403 차단

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)