### PR TITLE
feat: 회고 참여/마감/분석 로직 개선

### DIFF
--- a/codes/server/src/domain/member/entity/member_retro.rs
+++ b/codes/server/src/domain/member/entity/member_retro.rs
@@ -18,9 +18,6 @@ pub enum RetrospectStatus {
     /// 최종 제출 완료
     #[sea_orm(string_value = "SUBMITTED")]
     Submitted,
-    /// AI 분석 완료
-    #[sea_orm(string_value = "ANALYZED")]
-    Analyzed,
 }
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
@@ -29,10 +26,16 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub member_retro_id: i64,
     pub personal_insight: Option<String>,
+    /// 팀 AI 분석 요약 (개인별 분석 시점 기준)
+    pub insight: Option<String>,
+    /// 감정 랭킹 JSON (개인별 분석 시점 기준)
+    pub emotion_rank: Option<String>,
     pub member_id: Option<i64>,
     pub retrospect_id: i64,
     pub status: RetrospectStatus,
     pub submitted_at: Option<DateTime>,
+    /// 분석 완료 시점
+    pub analyzed_at: Option<DateTime>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/codes/server/src/domain/retrospect/dto.rs
+++ b/codes/server/src/domain/retrospect/dto.rs
@@ -723,22 +723,6 @@ pub struct AnalysisResponse {
     pub personal_missions: Vec<PersonalMissionItem>,
 }
 
-/// 회고 분석 API 응답 (AnalysisResponse + 인원 수 정보)
-#[derive(Debug, Serialize, ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct AnalysisApiResponse {
-    /// 회고방 전체를 위한 AI 분석 메시지
-    pub insight: String,
-    /// 감정 키워드 순위 리스트 (내림차순 정렬, 정확히 3개)
-    pub emotion_rank: Vec<EmotionRankItem>,
-    /// 사용자별 개인 맞춤 미션 리스트 (userId 오름차순 정렬)
-    pub personal_missions: Vec<PersonalMissionItem>,
-    /// 제출 완료한 멤버 수
-    pub submitted_count: i64,
-    /// 전체 참여자 수
-    pub participant_count: i64,
-}
-
 /// Swagger용 회고 분석 성공 응답 타입
 #[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -746,7 +730,7 @@ pub struct SuccessAnalysisResponse {
     pub is_success: bool,
     pub code: String,
     pub message: String,
-    pub result: AnalysisApiResponse,
+    pub result: AnalysisResponse,
 }
 
 // ============================================

--- a/codes/server/src/domain/retrospect/dto.rs
+++ b/codes/server/src/domain/retrospect/dto.rs
@@ -599,8 +599,6 @@ pub enum CurrentUserStatus {
     Draft,
     /// 회고 답변 최종 제출 완료
     Submitted,
-    /// AI 분석 완료
-    Analyzed,
 }
 
 /// 회고 상세 정보 응답 DTO
@@ -635,7 +633,7 @@ pub struct RetrospectMemberItem {
     pub member_id: i64,
     /// 멤버 이름 (닉네임)
     pub user_name: String,
-    /// 회고 참여 상태 (IN_PROGRESS, DRAFT, SUBMITTED, ANALYZED)
+    /// 회고 참여 상태 (IN_PROGRESS, DRAFT, SUBMITTED)
     pub status: RetrospectStatus,
 }
 
@@ -713,7 +711,7 @@ pub struct PersonalMissionItem {
     pub missions: Vec<MissionItem>,
 }
 
-/// 회고 분석 응답 데이터
+/// 회고 분석 응답 데이터 (AI 서비스에서 반환하는 원본)
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalysisResponse {
@@ -725,6 +723,22 @@ pub struct AnalysisResponse {
     pub personal_missions: Vec<PersonalMissionItem>,
 }
 
+/// 회고 분석 API 응답 (AnalysisResponse + 인원 수 정보)
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalysisApiResponse {
+    /// 회고방 전체를 위한 AI 분석 메시지
+    pub insight: String,
+    /// 감정 키워드 순위 리스트 (내림차순 정렬, 정확히 3개)
+    pub emotion_rank: Vec<EmotionRankItem>,
+    /// 사용자별 개인 맞춤 미션 리스트 (userId 오름차순 정렬)
+    pub personal_missions: Vec<PersonalMissionItem>,
+    /// 제출 완료한 멤버 수
+    pub submitted_count: i64,
+    /// 전체 참여자 수
+    pub participant_count: i64,
+}
+
 /// Swagger용 회고 분석 성공 응답 타입
 #[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -732,7 +746,7 @@ pub struct SuccessAnalysisResponse {
     pub is_success: bool,
     pub code: String,
     pub message: String,
-    pub result: AnalysisResponse,
+    pub result: AnalysisApiResponse,
 }
 
 // ============================================

--- a/codes/server/src/domain/retrospect/entity/retrospect.rs
+++ b/codes/server/src/domain/retrospect/entity/retrospect.rs
@@ -90,9 +90,6 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub retrospect_id: i64,
     pub title: String,
-    pub insight: Option<String>,
-    /// 감정 랭킹 JSON (EmotionRankItem 배열)
-    pub emotion_rank: Option<String>,
     /// 회고 질문 목록 JSON (Vec<String>)
     pub questions: Option<String>,
     pub retrospect_method: RetrospectMethod,

--- a/codes/server/src/domain/retrospect/handler.rs
+++ b/codes/server/src/domain/retrospect/handler.rs
@@ -13,7 +13,7 @@ use crate::utils::error::AppError;
 use crate::utils::BaseResponse;
 
 use super::dto::{
-    AnalysisApiResponse, AssistantRequest, AssistantResponse, CreateCommentRequest,
+    AnalysisResponse, AssistantRequest, AssistantResponse, CreateCommentRequest,
     CreateCommentResponse, CreateParticipantResponse, CreateRetrospectRequest,
     CreateRetrospectResponse, DeleteRetroRoomResponse, DraftSaveRequest, DraftSaveResponse,
     InviteCodeResponse, JoinRetroRoomRequest, JoinRetroRoomResponse, LikeToggleResponse,
@@ -686,7 +686,7 @@ pub async fn analyze_retrospective_handler(
     user: AuthUser,
     State(state): State<AppState>,
     Path(retrospect_id): Path<i64>,
-) -> Result<Json<BaseResponse<AnalysisApiResponse>>, AppError> {
+) -> Result<Json<BaseResponse<AnalysisResponse>>, AppError> {
     // retrospectId 검증 (1 이상의 양수)
     if retrospect_id < 1 {
         return Err(AppError::BadRequest(
@@ -728,7 +728,7 @@ pub async fn get_analysis_result(
     user: AuthUser,
     State(state): State<AppState>,
     Path(retrospect_id): Path<i64>,
-) -> Result<Json<BaseResponse<AnalysisApiResponse>>, AppError> {
+) -> Result<Json<BaseResponse<AnalysisResponse>>, AppError> {
     if retrospect_id < 1 {
         return Err(AppError::BadRequest(
             "retrospectId는 1 이상의 양수여야 합니다.".to_string(),

--- a/codes/server/src/domain/retrospect/handler.rs
+++ b/codes/server/src/domain/retrospect/handler.rs
@@ -13,7 +13,7 @@ use crate::utils::error::AppError;
 use crate::utils::BaseResponse;
 
 use super::dto::{
-    AnalysisResponse, AssistantRequest, AssistantResponse, CreateCommentRequest,
+    AnalysisApiResponse, AssistantRequest, AssistantResponse, CreateCommentRequest,
     CreateCommentResponse, CreateParticipantResponse, CreateRetrospectRequest,
     CreateRetrospectResponse, DeleteRetroRoomResponse, DraftSaveRequest, DraftSaveResponse,
     InviteCodeResponse, JoinRetroRoomRequest, JoinRetroRoomResponse, LikeToggleResponse,
@@ -686,7 +686,7 @@ pub async fn analyze_retrospective_handler(
     user: AuthUser,
     State(state): State<AppState>,
     Path(retrospect_id): Path<i64>,
-) -> Result<Json<BaseResponse<AnalysisResponse>>, AppError> {
+) -> Result<Json<BaseResponse<AnalysisApiResponse>>, AppError> {
     // retrospectId 검증 (1 이상의 양수)
     if retrospect_id < 1 {
         return Err(AppError::BadRequest(
@@ -728,7 +728,7 @@ pub async fn get_analysis_result(
     user: AuthUser,
     State(state): State<AppState>,
     Path(retrospect_id): Path<i64>,
-) -> Result<Json<BaseResponse<AnalysisResponse>>, AppError> {
+) -> Result<Json<BaseResponse<AnalysisApiResponse>>, AppError> {
     if retrospect_id < 1 {
         return Err(AppError::BadRequest(
             "retrospectId는 1 이상의 양수여야 합니다.".to_string(),

--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -30,7 +30,7 @@ use crate::domain::retrospect::entity::retro_room::Entity as RetroRoom;
 use crate::domain::retrospect::entity::retrospect::Entity as Retrospect;
 
 use super::dto::{
-    AnalysisApiResponse, AssistantRequest, AssistantResponse, CommentItem, CreateCommentRequest,
+    AnalysisResponse, AssistantRequest, AssistantResponse, CommentItem, CreateCommentRequest,
     CreateCommentResponse, CreateParticipantResponse, CreateRetrospectRequest,
     CreateRetrospectResponse, CurrentUserStatus, DeleteRetroRoomResponse, DraftItem,
     DraftSaveRequest, DraftSaveResponse, EmotionRankItem, GuideType, InviteCodeResponse,
@@ -2504,7 +2504,7 @@ impl RetrospectService {
         state: AppState,
         user_id: i64,
         retrospect_id: i64,
-    ) -> Result<AnalysisApiResponse, AppError> {
+    ) -> Result<AnalysisResponse, AppError> {
         info!(
             user_id = user_id,
             retrospect_id = retrospect_id,
@@ -2592,21 +2592,13 @@ impl RetrospectService {
             ));
         }
 
-        // 5. 전체 참여자 및 제출 멤버 수 조회
-        let all_participants = member_retro::Entity::find()
+        // 5. 제출 멤버 확인
+        let submitted_members: Vec<member_retro::Model> = member_retro::Entity::find()
             .filter(member_retro::Column::RetrospectId.eq(retrospect_id))
+            .filter(member_retro::Column::Status.eq(RetrospectStatus::Submitted))
             .all(&state.db)
             .await
             .map_err(|e| AppError::InternalError(e.to_string()))?;
-
-        let participant_count = all_participants.len() as i64;
-
-        let submitted_members: Vec<&member_retro::Model> = all_participants
-            .iter()
-            .filter(|mr| mr.status == RetrospectStatus::Submitted)
-            .collect();
-
-        let submitted_count = submitted_members.len() as i64;
 
         if submitted_members.is_empty() {
             return Err(AppError::RetroInsufficientData(
@@ -2771,12 +2763,10 @@ impl RetrospectService {
 
         info!(retrospect_id = retrospect_id, "회고 분석 완료");
 
-        Ok(AnalysisApiResponse {
+        Ok(AnalysisResponse {
             insight: analysis.insight,
             emotion_rank: analysis.emotion_rank,
             personal_missions: analysis.personal_missions,
-            submitted_count,
-            participant_count,
         })
     }
 
@@ -2785,7 +2775,7 @@ impl RetrospectService {
         state: AppState,
         user_id: i64,
         retrospect_id: i64,
-    ) -> Result<AnalysisApiResponse, AppError> {
+    ) -> Result<AnalysisResponse, AppError> {
         info!(
             user_id = user_id,
             retrospect_id = retrospect_id,
@@ -2852,26 +2842,12 @@ impl RetrospectService {
         });
 
         // 6. 전체 참여자/제출 수 조회
-        let all_participants = member_retro::Entity::find()
-            .filter(member_retro::Column::RetrospectId.eq(retrospect_id))
-            .all(&state.db)
-            .await
-            .map_err(|e| AppError::InternalError(e.to_string()))?;
-
-        let participant_count = all_participants.len() as i64;
-        let submitted_count = all_participants
-            .iter()
-            .filter(|mr| mr.status == RetrospectStatus::Submitted)
-            .count() as i64;
-
         info!(retrospect_id = retrospect_id, "분석 결과 조회 완료");
 
-        Ok(AnalysisApiResponse {
+        Ok(AnalysisResponse {
             insight,
             emotion_rank,
             personal_missions,
-            submitted_count,
-            participant_count,
         })
     }
 

--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -1990,6 +1990,7 @@ impl RetrospectService {
             &member_map,
             &responses,
             &response_member_map,
+            user_id,
         )?;
 
         info!(
@@ -2178,6 +2179,7 @@ impl RetrospectService {
         member_map: &HashMap<i64, String>,
         responses: &[response::Model],
         response_member_map: &HashMap<i64, i64>,
+        requester_id: i64,
     ) -> Result<Vec<u8>, AppError> {
         // 폰트 로딩
         let font_dir = std::env::var("PDF_FONT_DIR").unwrap_or_else(|_| "./fonts".to_string());
@@ -2297,7 +2299,9 @@ impl RetrospectService {
         doc.push(Break::new(0.5));
 
         // ===== 회고 인사이트 섹션 (member_retro에서 분석 결과 조회) =====
-        let analyzed_member_retro = member_retros.iter().find(|mr| mr.insight.is_some());
+        let analyzed_member_retro = member_retros
+            .iter()
+            .find(|mr| mr.member_id == Some(requester_id) && mr.insight.is_some());
         if let Some(mr) = analyzed_member_retro {
             if let Some(ref insight) = mr.insight {
                 doc.push(
@@ -2763,10 +2767,16 @@ impl RetrospectService {
 
         info!(retrospect_id = retrospect_id, "회고 분석 완료");
 
+        let personal_missions = analysis
+            .personal_missions
+            .into_iter()
+            .filter(|pm| pm.user_id == user_id)
+            .collect();
+
         Ok(AnalysisResponse {
             insight: analysis.insight,
             emotion_rank: analysis.emotion_rank,
-            personal_missions: analysis.personal_missions,
+            personal_missions,
         })
     }
 

--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -30,7 +30,7 @@ use crate::domain::retrospect::entity::retro_room::Entity as RetroRoom;
 use crate::domain::retrospect::entity::retrospect::Entity as Retrospect;
 
 use super::dto::{
-    AnalysisResponse, AssistantRequest, AssistantResponse, CommentItem, CreateCommentRequest,
+    AnalysisApiResponse, AssistantRequest, AssistantResponse, CommentItem, CreateCommentRequest,
     CreateCommentResponse, CreateParticipantResponse, CreateRetrospectRequest,
     CreateRetrospectResponse, CurrentUserStatus, DeleteRetroRoomResponse, DraftItem,
     DraftSaveRequest, DraftSaveResponse, EmotionRankItem, GuideType, InviteCodeResponse,
@@ -810,8 +810,7 @@ impl RetrospectService {
                     RetrospectListStatus::Completed
                 } else {
                     match user_status_map.get(&r.retrospect_id) {
-                        Some(member_retro::RetrospectStatus::Submitted)
-                        | Some(member_retro::RetrospectStatus::Analyzed) => {
+                        Some(member_retro::RetrospectStatus::Submitted) => {
                             RetrospectListStatus::Completed
                         }
                         Some(member_retro::RetrospectStatus::Draft) => RetrospectListStatus::Draft,
@@ -961,7 +960,6 @@ impl RetrospectService {
 
         let retrospect_model = retrospect::ActiveModel {
             title: Set(req.project_name.clone()),
-            insight: Set(None),
             questions: Set(Some(questions_json)),
             retrospect_method: Set(req.retrospect_method.clone()),
             created_at: Set(now),
@@ -1131,11 +1129,15 @@ impl RetrospectService {
         let retrospect_model =
             Self::find_retrospect_for_member(&state, user_id, retrospect_id).await?;
 
-        // 2. 회고가 시작되었는지 확인 (start_time 이후부터 참여 가능)
+        // 2. 참여 가능 시간 확인: 회고 생성 시점 ~ 회고 날짜 23:59:59 KST
         let now_kst = Utc::now().naive_utc() + chrono::Duration::hours(9);
-        if now_kst < retrospect_model.start_time {
-            return Err(AppError::RetrospectNotStarted(
-                "아직 시작되지 않은 회고입니다.".to_string(),
+        let participation_deadline = NaiveDateTime::new(
+            retrospect_model.start_time.date(),
+            NaiveTime::from_hms_opt(23, 59, 59).unwrap_or_default(),
+        );
+        if now_kst > participation_deadline {
+            return Err(AppError::RetrospectParticipationClosed(
+                "참여 가능 시간이 종료되었습니다.".to_string(),
             ));
         }
 
@@ -1446,9 +1448,7 @@ impl RetrospectService {
             })?;
 
         // 5. 이미 제출 완료 여부 확인 (행 잠금 후 검사로 경쟁 조건 방지)
-        if member_retro_model.status == RetrospectStatus::Submitted
-            || member_retro_model.status == RetrospectStatus::Analyzed
-        {
+        if member_retro_model.status == RetrospectStatus::Submitted {
             return Err(AppError::RetroAlreadySubmitted(
                 "이미 제출이 완료된 회고입니다.".to_string(),
             ));
@@ -1534,13 +1534,10 @@ impl RetrospectService {
             "보관함 조회 요청"
         );
 
-        // 1. 사용자가 참여한 회고 중 제출 완료/분석 완료 상태만 조회
+        // 1. 사용자가 참여한 회고 중 제출 완료 상태만 조회
         let mut member_retro_query = member_retro::Entity::find()
             .filter(member_retro::Column::MemberId.eq(user_id))
-            .filter(
-                member_retro::Column::Status
-                    .is_in([RetrospectStatus::Submitted, RetrospectStatus::Analyzed]),
-            );
+            .filter(member_retro::Column::Status.eq(RetrospectStatus::Submitted));
 
         // 2. 기간 필터 적용
         if let Some(days) = range_filter.days() {
@@ -1802,7 +1799,6 @@ impl RetrospectService {
                 RetrospectStatus::InProgress => CurrentUserStatus::InProgress,
                 RetrospectStatus::Draft => CurrentUserStatus::Draft,
                 RetrospectStatus::Submitted => CurrentUserStatus::Submitted,
-                RetrospectStatus::Analyzed => CurrentUserStatus::Analyzed,
             })
             .unwrap_or(CurrentUserStatus::NotParticipated);
 
@@ -2300,15 +2296,18 @@ impl RetrospectService {
         }
         doc.push(Break::new(0.5));
 
-        // ===== 회고방 인사이트 섹션 =====
-        if let Some(ref insight) = retrospect_model.insight {
-            doc.push(
-                Paragraph::new("Retro Room Insight")
-                    .styled(style::Style::new().bold().with_font_size(14)),
-            );
-            doc.push(Break::new(0.3));
-            doc.push(Paragraph::new(insight.clone()));
-            doc.push(Break::new(0.5));
+        // ===== 회고 인사이트 섹션 (member_retro에서 분석 결과 조회) =====
+        let analyzed_member_retro = member_retros.iter().find(|mr| mr.insight.is_some());
+        if let Some(mr) = analyzed_member_retro {
+            if let Some(ref insight) = mr.insight {
+                doc.push(
+                    Paragraph::new("Retro Room Insight")
+                        .styled(style::Style::new().bold().with_font_size(14)),
+                );
+                doc.push(Break::new(0.3));
+                doc.push(Paragraph::new(insight.clone()));
+                doc.push(Break::new(0.5));
+            }
         }
 
         // ===== 질문/답변 섹션 =====
@@ -2500,12 +2499,12 @@ impl RetrospectService {
         Ok(())
     }
 
-    /// 회고 분석 (API-022)
+    /// 회고 분석 (API-022) — 개인별 분석 결과 저장
     pub async fn analyze_retrospective(
         state: AppState,
         user_id: i64,
         retrospect_id: i64,
-    ) -> Result<AnalysisResponse, AppError> {
+    ) -> Result<AnalysisApiResponse, AppError> {
         info!(
             user_id = user_id,
             retrospect_id = retrospect_id,
@@ -2528,26 +2527,28 @@ impl RetrospectService {
                 AppError::RetrospectNotFound("존재하지 않는 회고 세션입니다.".to_string())
             })?;
 
-        // 2-1. 이미 분석 완료 여부 확인 (재분석 방지)
-        if retrospect_model.insight.is_some() {
-            return Err(AppError::RetroAlreadyAnalyzed(
-                "이미 분석이 완료된 회고입니다.".to_string(),
+        // 3. 해당 사용자의 member_retro 확인 (참여 + 제출 여부)
+        let user_member_retro = member_retro::Entity::find()
+            .filter(member_retro::Column::MemberId.eq(user_id))
+            .filter(member_retro::Column::RetrospectId.eq(retrospect_id))
+            .one(&state.db)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?
+            .ok_or_else(|| {
+                AppError::RetroRoomAccessDenied("해당 회고에 참여하지 않았습니다.".to_string())
+            })?;
+
+        // 3-1. 제출 완료 상태인지 확인
+        if user_member_retro.status != RetrospectStatus::Submitted {
+            return Err(AppError::RetroInsufficientData(
+                "회고를 제출한 후에 분석할 수 있습니다.".to_string(),
             ));
         }
 
-        // 3. 회고방 멤버십 확인 (회고방 기반 접근 제어)
-        let is_room_member = member_retro_room::Entity::find()
-            .filter(member_retro_room::Column::MemberId.eq(user_id))
-            .filter(
-                member_retro_room::Column::RetrospectRoomId.eq(retrospect_model.retrospect_room_id),
-            )
-            .one(&state.db)
-            .await
-            .map_err(|e| AppError::InternalError(e.to_string()))?;
-
-        if is_room_member.is_none() {
-            return Err(AppError::RetroRoomAccessDenied(
-                "해당 회고방에 접근 권한이 없습니다.".to_string(),
+        // 3-2. 이미 분석 완료 여부 확인 (analyzed_at 기준)
+        if user_member_retro.analyzed_at.is_some() {
+            return Err(AppError::RetroAlreadyAnalyzed(
+                "이미 분석이 완료되었습니다.".to_string(),
             ));
         }
 
@@ -2563,15 +2564,27 @@ impl RetrospectService {
                 .ok_or_else(|| AppError::InternalError("시간 계산 오류".to_string()))?
                 - kst_offset; // UTC로 변환
 
-        // 현재 월에 insight가 NOT NULL인 회고 수 카운트 (분석 시점 = updated_at 기준)
-        let monthly_analysis_count = retrospect::Entity::find()
+        // 해당 회고방의 회고들에 속한 member_retro 중 이번 달에 분석된 건수 카운트
+        let retrospect_ids_in_room: Vec<i64> = retrospect::Entity::find()
             .filter(retrospect::Column::RetrospectRoomId.eq(retrospect_room_id))
-            .filter(retrospect::Column::Insight.is_not_null())
-            .filter(retrospect::Column::UpdatedAt.gte(current_month_start))
-            .count(&state.db)
+            .all(&state.db)
             .await
             .map_err(|e| AppError::InternalError(e.to_string()))?
-            as i32;
+            .iter()
+            .map(|r| r.retrospect_id)
+            .collect();
+
+        let monthly_analysis_count = if retrospect_ids_in_room.is_empty() {
+            0
+        } else {
+            member_retro::Entity::find()
+                .filter(member_retro::Column::RetrospectId.is_in(retrospect_ids_in_room))
+                .filter(member_retro::Column::AnalyzedAt.is_not_null())
+                .filter(member_retro::Column::AnalyzedAt.gte(current_month_start))
+                .count(&state.db)
+                .await
+                .map_err(|e| AppError::InternalError(e.to_string()))? as i32
+        };
 
         if monthly_analysis_count >= 10 {
             return Err(AppError::AiMonthlyLimitExceeded(
@@ -2579,17 +2592,21 @@ impl RetrospectService {
             ));
         }
 
-        // 5. 최소 데이터 기준 확인
-        // 5-1. 제출 완료 참여자 수 (member_retro에서 status = SUBMITTED 또는 ANALYZED)
-        let submitted_members = member_retro::Entity::find()
+        // 5. 전체 참여자 및 제출 멤버 수 조회
+        let all_participants = member_retro::Entity::find()
             .filter(member_retro::Column::RetrospectId.eq(retrospect_id))
-            .filter(
-                member_retro::Column::Status
-                    .is_in([RetrospectStatus::Submitted, RetrospectStatus::Analyzed]),
-            )
             .all(&state.db)
             .await
             .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+        let participant_count = all_participants.len() as i64;
+
+        let submitted_members: Vec<&member_retro::Model> = all_participants
+            .iter()
+            .filter(|mr| mr.status == RetrospectStatus::Submitted)
+            .collect();
+
+        let submitted_count = submitted_members.len() as i64;
 
         if submitted_members.is_empty() {
             return Err(AppError::RetroInsufficientData(
@@ -2729,64 +2746,46 @@ impl RetrospectService {
         // personalMissions의 userId 오름차순 정렬
         analysis.personal_missions.sort_by_key(|pm| pm.user_id);
 
+        // 9. 해당 사용자의 member_retro에만 분석 결과 저장
         let insight = analysis.insight.clone();
-        let personal_missions = &analysis.personal_missions;
-
-        // 9. 트랜잭션으로 결과 저장
-        let txn = state
-            .db
-            .begin()
-            .await
-            .map_err(|e| AppError::InternalError(e.to_string()))?;
-
-        // 9-1. retrospects.insight + emotion_rank 업데이트
         let emotion_rank_json = serde_json::to_string(&analysis.emotion_rank)
             .map_err(|e| AppError::InternalError(format!("emotion_rank 직렬화 실패: {}", e)))?;
-        let mut retrospect_active: retrospect::ActiveModel = retrospect_model.clone().into();
-        retrospect_active.insight = Set(Some(insight.clone()));
-        retrospect_active.emotion_rank = Set(Some(emotion_rank_json));
-        retrospect_active.updated_at = Set(Utc::now().naive_utc());
-        retrospect_active
-            .update(&txn)
-            .await
-            .map_err(|e| AppError::InternalError(e.to_string()))?;
 
-        // 9-2. 각 member_retro.personal_insight 업데이트 + status = ANALYZED
-        for mr in &submitted_members {
-            // personal_missions에서 해당 member_id의 미션 찾기
-            let personal_insight = mr
-                .member_id
-                .and_then(|member_id| personal_missions.iter().find(|pm| pm.user_id == member_id))
-                .map(|pm| serde_json::to_string(&pm.missions))
-                .transpose()
-                .map_err(|e| {
-                    AppError::InternalError(format!("personal_insight 직렬화 실패: {}", e))
-                })?;
+        let personal_insight = analysis
+            .personal_missions
+            .iter()
+            .find(|pm| pm.user_id == user_id)
+            .map(|pm| serde_json::to_string(&pm.missions))
+            .transpose()
+            .map_err(|e| AppError::InternalError(format!("personal_insight 직렬화 실패: {}", e)))?;
 
-            let mut mr_active: member_retro::ActiveModel = mr.clone().into();
-            mr_active.personal_insight = Set(personal_insight);
-            mr_active.status = Set(RetrospectStatus::Analyzed);
-            mr_active
-                .update(&txn)
-                .await
-                .map_err(|e| AppError::InternalError(e.to_string()))?;
-        }
-
-        txn.commit()
+        let mut mr_active: member_retro::ActiveModel = user_member_retro.into();
+        mr_active.insight = Set(Some(insight.clone()));
+        mr_active.emotion_rank = Set(Some(emotion_rank_json));
+        mr_active.personal_insight = Set(personal_insight);
+        mr_active.analyzed_at = Set(Some(Utc::now().naive_utc()));
+        mr_active
+            .update(&state.db)
             .await
             .map_err(|e| AppError::InternalError(e.to_string()))?;
 
         info!(retrospect_id = retrospect_id, "회고 분석 완료");
 
-        Ok(analysis)
+        Ok(AnalysisApiResponse {
+            insight: analysis.insight,
+            emotion_rank: analysis.emotion_rank,
+            personal_missions: analysis.personal_missions,
+            submitted_count,
+            participant_count,
+        })
     }
 
-    /// API-032: 분석 결과 조회
+    /// API-032: 분석 결과 조회 (개인별 member_retro 기준)
     pub async fn get_analysis_result(
         state: AppState,
         user_id: i64,
         retrospect_id: i64,
-    ) -> Result<AnalysisResponse, AppError> {
+    ) -> Result<AnalysisApiResponse, AppError> {
         info!(
             user_id = user_id,
             retrospect_id = retrospect_id,
@@ -2794,16 +2793,33 @@ impl RetrospectService {
         );
 
         // 1. 회고 존재 + 접근 권한 확인 (기존 헬퍼 재사용)
-        let retrospect_model =
+        let _retrospect_model =
             Self::find_retrospect_for_member(&state, user_id, retrospect_id).await?;
 
-        // 2. 분석 완료 여부 확인
-        let insight = retrospect_model.insight.ok_or_else(|| {
-            AppError::AnalysisNotReady("분석이 아직 완료되지 않은 회고입니다.".to_string())
+        // 2. 해당 사용자의 member_retro에서 분석 결과 조회
+        let user_member_retro = member_retro::Entity::find()
+            .filter(member_retro::Column::MemberId.eq(user_id))
+            .filter(member_retro::Column::RetrospectId.eq(retrospect_id))
+            .one(&state.db)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?
+            .ok_or_else(|| {
+                AppError::AnalysisNotReady("해당 회고에 참여하지 않았습니다.".to_string())
+            })?;
+
+        // 3. 분석 완료 여부 확인 (analyzed_at 기준)
+        if user_member_retro.analyzed_at.is_none() {
+            return Err(AppError::AnalysisNotReady(
+                "분석이 아직 완료되지 않은 회고입니다.".to_string(),
+            ));
+        }
+
+        let insight = user_member_retro.insight.clone().ok_or_else(|| {
+            AppError::InternalError("분석 완료 상태이나 insight가 없습니다.".to_string())
         })?;
 
         // 4. emotion_rank 복원
-        let emotion_rank: Vec<EmotionRankItem> = retrospect_model
+        let emotion_rank: Vec<EmotionRankItem> = user_member_retro
             .emotion_rank
             .as_deref()
             .map(serde_json::from_str)
@@ -2811,72 +2827,51 @@ impl RetrospectService {
             .map_err(|e| AppError::InternalError(format!("emotion_rank 역직렬화 실패: {}", e)))?
             .unwrap_or_default();
 
-        // 5. personal_missions 복원 (member_retro + member 조회)
-        let member_retros = member_retro::Entity::find()
+        // 5. personal_missions 복원 (현재 사용자의 personal_insight만)
+        let mut personal_missions: Vec<PersonalMissionItem> = Vec::new();
+
+        let member_model = member::Entity::find_by_id(user_id)
+            .one(&state.db)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+        let username = member_model
+            .and_then(|m| m.nickname.clone().filter(|s| !s.is_empty()))
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        let missions = user_member_retro
+            .personal_insight
+            .as_deref()
+            .map(parse_personal_insight)
+            .unwrap_or_default();
+
+        personal_missions.push(PersonalMissionItem {
+            user_id,
+            user_name: username,
+            missions,
+        });
+
+        // 6. 전체 참여자/제출 수 조회
+        let all_participants = member_retro::Entity::find()
             .filter(member_retro::Column::RetrospectId.eq(retrospect_id))
-            .filter(member_retro::Column::Status.eq(RetrospectStatus::Analyzed))
-            .order_by_asc(member_retro::Column::MemberRetroId)
             .all(&state.db)
             .await
             .map_err(|e| AppError::InternalError(e.to_string()))?;
 
-        let member_ids: Vec<i64> = member_retros.iter().filter_map(|mr| mr.member_id).collect();
-
-        let members = if member_ids.is_empty() {
-            vec![]
-        } else {
-            member::Entity::find()
-                .filter(member::Column::MemberId.is_in(member_ids))
-                .all(&state.db)
-                .await
-                .map_err(|e| AppError::InternalError(e.to_string()))?
-        };
-
-        let member_map: HashMap<i64, String> = members
+        let participant_count = all_participants.len() as i64;
+        let submitted_count = all_participants
             .iter()
-            .map(|m| {
-                let nickname = m
-                    .nickname
-                    .clone()
-                    .filter(|s| !s.is_empty())
-                    .unwrap_or_else(|| "Unknown".to_string());
-                (m.member_id, nickname)
-            })
-            .collect();
-
-        // personal_insight를 파싱하여 missions 복원
-        let mut personal_missions: Vec<PersonalMissionItem> = Vec::new();
-        for mr in &member_retros {
-            let Some(member_id) = mr.member_id else {
-                continue;
-            };
-            let username = member_map
-                .get(&member_id)
-                .cloned()
-                .unwrap_or_else(|| "Unknown".to_string());
-
-            let missions = mr
-                .personal_insight
-                .as_deref()
-                .map(parse_personal_insight)
-                .unwrap_or_default();
-
-            personal_missions.push(PersonalMissionItem {
-                user_id: member_id,
-                user_name: username,
-                missions,
-            });
-        }
-
-        // userId 오름차순 정렬
-        personal_missions.sort_by_key(|pm| pm.user_id);
+            .filter(|mr| mr.status == RetrospectStatus::Submitted)
+            .count() as i64;
 
         info!(retrospect_id = retrospect_id, "분석 결과 조회 완료");
 
-        Ok(AnalysisResponse {
+        Ok(AnalysisApiResponse {
             insight,
             emotion_rank,
             personal_missions,
+            submitted_count,
+            participant_count,
         })
     }
 
@@ -3509,7 +3504,7 @@ impl RetrospectService {
             .map_err(|e| AppError::InternalError(e.to_string()))?;
 
         if let Some(mr) = &member_retro_model {
-            if mr.status == RetrospectStatus::Submitted || mr.status == RetrospectStatus::Analyzed {
+            if mr.status == RetrospectStatus::Submitted {
                 return Err(AppError::RetroAlreadySubmitted(
                     "이미 제출된 회고에서는 어시스턴트를 사용할 수 없습니다.".to_string(),
                 ));

--- a/codes/server/src/utils/error.rs
+++ b/codes/server/src/utils/error.rs
@@ -102,6 +102,9 @@ pub enum AppError {
     /// RETRO4002: 아직 시작되지 않은 회고 (400)
     RetrospectNotStarted(String),
 
+    /// RETRO4008: 참여 가능 시간이 종료됨 (400)
+    RetrospectParticipationClosed(String),
+
     /// RES4041: 존재하지 않는 회고 답변 (404)
     ResponseNotFound(String),
 
@@ -203,6 +206,7 @@ impl AppError {
             AppError::RetrospectNotFound(msg) => msg.clone(),
             AppError::ParticipantDuplicate(msg) => msg.clone(),
             AppError::RetrospectNotStarted(msg) => msg.clone(),
+            AppError::RetrospectParticipationClosed(msg) => msg.clone(),
             AppError::ResponseNotFound(msg) => msg.clone(),
             AppError::CommentTooLong(msg) => msg.clone(),
             AppError::RetroAnswersMissing(msg) => msg.clone(),
@@ -260,6 +264,7 @@ impl AppError {
             AppError::RetrospectNotFound(_) => "RETRO4041",
             AppError::ParticipantDuplicate(_) => "RETRO4091",
             AppError::RetrospectNotStarted(_) => "RETRO4002",
+            AppError::RetrospectParticipationClosed(_) => "RETRO4008",
             AppError::ResponseNotFound(_) => "RES4041",
             AppError::CommentTooLong(_) => "RES4001",
             AppError::RetroAnswersMissing(_) => "RETRO4002",
@@ -317,6 +322,7 @@ impl AppError {
             AppError::RetrospectNotFound(_) => StatusCode::NOT_FOUND,
             AppError::ParticipantDuplicate(_) => StatusCode::CONFLICT,
             AppError::RetrospectNotStarted(_) => StatusCode::BAD_REQUEST,
+            AppError::RetrospectParticipationClosed(_) => StatusCode::BAD_REQUEST,
             AppError::ResponseNotFound(_) => StatusCode::NOT_FOUND,
             AppError::CommentTooLong(_) => StatusCode::BAD_REQUEST,
             AppError::RetroAnswersMissing(_) => StatusCode::BAD_REQUEST,


### PR DESCRIPTION
# ☝️Issue Number
- #132

## 📌 Summary / 개요
- 회고 참여 가능 시간을 당일 23:59:59까지로 변경
- `ANALYZED` 상태 제거, 분석은 `SUBMITTED` 상태의 멤버만 대상
- 팀 분석 결과를 `retrospects` 테이블에서 `member_retro` 테이블로 이동 (개인별 독립 분석)
- 참여/마감 에러 코드 추가 (`RETRO4008`)

## 🔁 Changes / 변경 사항
### Modified
- `codes/server/src/domain/member/entity/member_retro.rs`: `Analyzed` 상태 제거, `insight`/`emotion_rank`/`analyzed_at` 필드 추가
- `codes/server/src/domain/retrospect/entity/retrospect.rs`: `insight`/`emotion_rank` 필드 제거
- `codes/server/src/domain/retrospect/dto.rs`: `Analyzed` 상태 제거, `AnalysisApiResponse`에 `submittedCount`/`participantCount` 필드 추가
- `codes/server/src/domain/retrospect/handler.rs`: 분석 API 반환 타입을 `AnalysisApiResponse`로 변경
- `codes/server/src/domain/retrospect/service.rs`: 참여 시간 로직, 분석 저장/조회 로직, 월간 제한 카운트 로직 전면 개편
- `codes/server/src/utils/error.rs`: `RetrospectParticipationClosed` 에러 타입 추가

## ✅ Test Plan
- [x] 단위 테스트 통과
- [x] `cargo test` 전체 통과

## ☑️ Checklist
- [x] `cargo fmt --check` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo test` 통과

## 👀 Additional Notes / 기타 사항
- DB 마이그레이션 필요: `member_retro` 테이블에 `insight`, `emotion_rank`, `analyzed_at` 컬럼 추가 및 `retrospects` 테이블에서 `insight`, `emotion_rank` 컬럼 제거
- `RetrospectStatus` enum에서 `ANALYZED` 값 제거 필요

## 🔗 Related Issues
- Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling for closed retrospect participation windows.

* **Updates**
  * Participation cutoff now enforced daily at 23:59:59 KST.
  * Removed the previous "Analyzed" public status from user-visible status values.
  * Analysis is stored and returned per-user (includes per-user insight and analyzed timestamp); responses include more granular submission and participant counts.

* **Documentation**
  * Updated status and analysis descriptions to match new per-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->