### PR TITLE
feat: 답변 리스트 조회 응답에 submittedAt 필드 추가 (#139)

### DIFF
--- a/codes/server/src/domain/retrospect/dto.rs
+++ b/codes/server/src/domain/retrospect/dto.rs
@@ -867,6 +867,8 @@ pub struct ResponseListItem {
     pub like_count: i64,
     /// 해당 답변의 댓글 수
     pub comment_count: i64,
+    /// 회고 제출 시간
+    pub submitted_at: Option<chrono::NaiveDateTime>,
 }
 
 /// 답변 카테고리별 조회 응답 DTO
@@ -1974,6 +1976,10 @@ mod tests {
             content: "이번 스프린트에서 테스트 코드를 꼼꼼히 짠 것이 좋았습니다.".to_string(),
             like_count: 12,
             comment_count: 3,
+            submitted_at: Some(
+                chrono::NaiveDateTime::parse_from_str("2026-02-27T18:00:00", "%Y-%m-%dT%H:%M:%S")
+                    .unwrap(),
+            ),
         };
 
         // Act
@@ -1985,11 +1991,13 @@ mod tests {
         assert!(json["content"].as_str().unwrap().contains("테스트 코드"));
         assert_eq!(json["likeCount"], 12);
         assert_eq!(json["commentCount"], 3);
+        assert!(json["submittedAt"].is_string());
         // snake_case 키가 없는지 확인
         assert!(json.get("response_id").is_none());
         assert!(json.get("user_name").is_none());
         assert!(json.get("like_count").is_none());
         assert!(json.get("comment_count").is_none());
+        assert!(json.get("submitted_at").is_none());
     }
 
     #[test]
@@ -2001,6 +2009,7 @@ mod tests {
             content: "테스트 답변".to_string(),
             like_count: 0,
             comment_count: 0,
+            submitted_at: None,
         };
 
         // Act
@@ -2026,6 +2035,13 @@ mod tests {
                     content: "좋은 점".to_string(),
                     like_count: 12,
                     comment_count: 3,
+                    submitted_at: Some(
+                        chrono::NaiveDateTime::parse_from_str(
+                            "2026-02-27T18:00:00",
+                            "%Y-%m-%dT%H:%M:%S",
+                        )
+                        .unwrap(),
+                    ),
                 },
                 ResponseListItem {
                     response_id: 456,
@@ -2033,6 +2049,13 @@ mod tests {
                     content: "기한 맞춰서".to_string(),
                     like_count: 12,
                     comment_count: 21,
+                    submitted_at: Some(
+                        chrono::NaiveDateTime::parse_from_str(
+                            "2026-02-27T17:30:00",
+                            "%Y-%m-%dT%H:%M:%S",
+                        )
+                        .unwrap(),
+                    ),
                 },
             ],
             has_next: true,
@@ -2081,6 +2104,7 @@ mod tests {
                 content: "마지막 답변".to_string(),
                 like_count: 1,
                 comment_count: 0,
+                submitted_at: None,
             }],
             has_next: false,
             next_cursor: None,
@@ -2109,6 +2133,13 @@ mod tests {
                     content: "테스트 답변".to_string(),
                     like_count: 5,
                     comment_count: 2,
+                    submitted_at: Some(
+                        chrono::NaiveDateTime::parse_from_str(
+                            "2026-02-27T18:00:00",
+                            "%Y-%m-%dT%H:%M:%S",
+                        )
+                        .unwrap(),
+                    ),
                 }],
                 has_next: false,
                 next_cursor: None,

--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -3089,7 +3089,7 @@ impl RetrospectService {
             .collect();
 
         let members = member::Entity::find()
-            .filter(member::Column::MemberId.is_in(member_ids))
+            .filter(member::Column::MemberId.is_in(member_ids.clone()))
             .all(&state.db)
             .await
             .map_err(|e| AppError::InternalError(e.to_string()))?;
@@ -3097,7 +3097,23 @@ impl RetrospectService {
         let member_map: HashMap<i64, &member::Model> =
             members.iter().map(|m| (m.member_id, m)).collect();
 
-        // 8. 좋아요 수 집계
+        // 8. member_retro에서 submitted_at 조회
+        let member_retros = member_retro::Entity::find()
+            .filter(member_retro::Column::RetrospectId.eq(retrospect_id))
+            .filter(member_retro::Column::MemberId.is_in(member_ids.clone()))
+            .all(&state.db)
+            .await
+            .map_err(|e| AppError::InternalError(e.to_string()))?;
+
+        let member_submitted_at_map: HashMap<i64, chrono::NaiveDateTime> = member_retros
+            .iter()
+            .filter_map(|mr| {
+                mr.member_id
+                    .and_then(|mid| mr.submitted_at.map(|sat| (mid, sat)))
+            })
+            .collect();
+
+        // 9. 좋아요 수 집계
         let like_counts: Vec<(i64, i64)> = response_like::Entity::find()
             .filter(response_like::Column::ResponseId.is_in(page_response_ids.clone()))
             .select_only()
@@ -3111,7 +3127,7 @@ impl RetrospectService {
 
         let like_count_map: HashMap<i64, i64> = like_counts.into_iter().collect();
 
-        // 9. 댓글 수 집계
+        // 10. 댓글 수 집계
         let comment_counts: Vec<(i64, i64)> = response_comment::Entity::find()
             .filter(response_comment::Column::ResponseId.is_in(page_response_ids.clone()))
             .select_only()
@@ -3125,7 +3141,7 @@ impl RetrospectService {
 
         let comment_count_map: HashMap<i64, i64> = comment_counts.into_iter().collect();
 
-        // 10. DTO 변환
+        // 11. DTO 변환
         let response_items: Vec<ResponseListItem> = page_responses
             .iter()
             .map(|r| {
@@ -3134,6 +3150,8 @@ impl RetrospectService {
                     .and_then(|mid| member_map.get(&mid))
                     .and_then(|m| m.nickname.clone())
                     .unwrap_or_default();
+                let submitted_at =
+                    member_id.and_then(|mid| member_submitted_at_map.get(&mid).copied());
 
                 ResponseListItem {
                     response_id: r.response_id,
@@ -3141,11 +3159,12 @@ impl RetrospectService {
                     content: r.content.clone(),
                     like_count: like_count_map.get(&r.response_id).copied().unwrap_or(0),
                     comment_count: comment_count_map.get(&r.response_id).copied().unwrap_or(0),
+                    submitted_at,
                 }
             })
             .collect();
 
-        // 11. 다음 커서 계산
+        // 12. 다음 커서 계산
         let next_cursor = if has_next {
             response_items.last().map(|r| r.response_id)
         } else {

--- a/codes/server/src/domain/retrospect/service.rs
+++ b/codes/server/src/domain/retrospect/service.rs
@@ -3105,11 +3105,12 @@ impl RetrospectService {
             .await
             .map_err(|e| AppError::InternalError(e.to_string()))?;
 
+        let kst_offset = chrono::Duration::hours(9);
         let member_submitted_at_map: HashMap<i64, chrono::NaiveDateTime> = member_retros
             .iter()
             .filter_map(|mr| {
                 mr.member_id
-                    .and_then(|mid| mr.submitted_at.map(|sat| (mid, sat)))
+                    .and_then(|mid| mr.submitted_at.map(|sat| (mid, sat + kst_offset)))
             })
             .collect();
 

--- a/codes/server/tests/retrospect_responses_list_test.rs
+++ b/codes/server/tests/retrospect_responses_list_test.rs
@@ -201,14 +201,16 @@ mod responses_test_helpers {
                                 "userName": "제이슨",
                                 "content": "이번 스프린트에서 테스트 코드를 꼼꼼히 짠 것이 좋았습니다.",
                                 "likeCount": 12,
-                                "commentCount": 3
+                                "commentCount": 3,
+                                "submittedAt": "2026-02-27T18:00:00"
                             },
                             {
                                 "responseId": 456,
                                 "userName": "김민수",
                                 "content": "기한 맞춰서 작업하는 것을 잘했고요...",
                                 "likeCount": 12,
-                                "commentCount": 21
+                                "commentCount": 21,
+                                "submittedAt": "2026-02-27T17:30:00"
                             }
                         ],
                         "hasNext": true,
@@ -226,7 +228,8 @@ mod responses_test_helpers {
                                 "userName": "제이슨",
                                 "content": "테스트 코드를 꼼꼼히 짠 것이 좋았습니다.",
                                 "likeCount": 12,
-                                "commentCount": 3
+                                "commentCount": 3,
+                                "submittedAt": "2026-02-27T18:00:00"
                             }
                         ],
                         "hasNext": false,
@@ -627,12 +630,14 @@ async fn api020_should_return_correct_response_fields() {
     assert!(first_response["content"].is_string());
     assert!(first_response["likeCount"].is_number());
     assert!(first_response["commentCount"].is_number());
+    assert!(first_response["submittedAt"].is_string());
 
     // 값 검증
     assert_eq!(first_response["responseId"], 501);
     assert_eq!(first_response["userName"], "제이슨");
     assert_eq!(first_response["likeCount"], 12);
     assert_eq!(first_response["commentCount"], 3);
+    assert_eq!(first_response["submittedAt"], "2026-02-27T18:00:00");
 }
 
 /// [API-020] 페이지네이션 hasNext/nextCursor 검증 테스트
@@ -788,6 +793,8 @@ async fn api020_should_use_camel_case_field_names_in_response() {
     assert!(first.get("like_count").is_none());
     assert!(first.get("commentCount").is_some());
     assert!(first.get("comment_count").is_none());
+    assert!(first.get("submittedAt").is_some());
+    assert!(first.get("submitted_at").is_none());
 }
 
 /// [API-020] responseId 내림차순 정렬 검증 테스트

--- a/docs/reviews/add-submitted-at-to-response.md
+++ b/docs/reviews/add-submitted-at-to-response.md
@@ -1,0 +1,41 @@
+# 답변 응답에 submittedAt 필드 추가 리뷰
+
+## 개요
+답변 리스트 조회 API(API-020) 응답에 `submittedAt` 필드를 추가하여 프론트엔드에서 "12분 전"과 같은 상대 시간 표시가 가능하도록 합니다.
+
+## 변경 사항
+
+### 1. DTO 변경 (`dto.rs`)
+- `ResponseListItem`에 `submitted_at: Option<chrono::NaiveDateTime>` 필드 추가
+- JSON 직렬화 시 `submittedAt`(camelCase)로 출력
+
+### 2. 서비스 변경 (`service.rs`)
+- `member_retro` 테이블에서 해당 회고의 `submitted_at` 조회
+- `member_id`를 키로 한 `member_submitted_at_map` 생성
+- 각 응답의 작성자 `member_id`를 통해 `submitted_at` 매핑
+
+### 3. 테스트 변경
+- DTO 직렬화 단위 테스트에 `submitted_at` 필드 추가
+- 통합 테스트 mock 데이터에 `submittedAt` 필드 추가
+- camelCase 필드명 검증 테스트에 `submittedAt` 검증 추가
+
+## 응답 형식
+
+```json
+{
+  "responseId": 751,
+  "userName": "아아",
+  "content": "답변 내용",
+  "likeCount": 0,
+  "commentCount": 0,
+  "submittedAt": "2026-02-27T18:00:00"
+}
+```
+
+- `submittedAt`은 `member_retro.submitted_at` 값을 사용
+- 제출 전 상태이거나 멤버 정보가 없는 경우 `null`
+
+## 체크리스트
+- [x] cargo test 통과
+- [x] cargo clippy -- -D warnings 경고 없음
+- [x] cargo fmt 적용


### PR DESCRIPTION
## Summary
- 답변 리스트 조회 API(API-020) 응답에 `submittedAt` 필드 추가
- `member_retro` 테이블의 `submitted_at` 컬럼을 데이터 출처로 사용
- 프론트엔드에서 "12분 전"과 같은 상대 시간 표시 가능

## 변경 파일
- `dto.rs`: `ResponseListItem`에 `submitted_at: Option<NaiveDateTime>` 필드 추가
- `service.rs`: `member_retro` 조회 및 `submitted_at` 매핑 로직 추가
- 테스트: mock 데이터 및 필드 검증 업데이트

## 응답 예시
```json
{
  "responseId": 751,
  "userName": "아아",
  "content": "답변 내용",
  "likeCount": 0,
  "commentCount": 0,
  "submittedAt": "2026-02-27T18:00:00"
}
```

## Test plan
- [x] `cargo test` 전체 통과
- [x] `cargo clippy -- -D warnings` 경고 없음
- [x] `cargo fmt` 적용

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Response lists now include an optional submittedAt timestamp for each item, showing when responses were submitted.
* **Tests**
  * API tests updated to verify submittedAt appears in camelCase, is serialized as a string when present, and matches expected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->